### PR TITLE
feat: Sentry entegrasyonu, ikon güncellemesi ve code-review düzeltmeleri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+#### Added
+- Sentry crash and error monitoring (SDK 9.16.1) with breadcrumbs on every service refresh
+
+#### Changed
+- Menu bar icon updated to new Mimir/Viking design
+- Icon pre-built at startup in two states (normal, low-quota); no disk I/O on 60s refresh ticks
+- Low-quota indicator changed from red overlay to a red dot badge on the icon corner
+- `--csrf_token` flag parsing now supports both space-separated and `=`-style formats
+
+#### Fixed
+- Menu bar icon was blurry on Retina displays due to `lockFocus` creating a 1× bitmap — replaced with deferred `NSImage` drawing handler that renders at native scale
+- Icon was hard to see on dark menu bars — replaced with new high-contrast design
+- `contentTintColor` now explicitly reset on each refresh to prevent stale tint state
+
 ### [1.1.0] - 2026-05-02
 
 #### Added
@@ -48,6 +62,20 @@ Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
 
 ### [Yayımlanmadı]
+
+#### Eklendi
+- Sentry çökme ve hata izleme entegrasyonu (SDK 9.16.1); her servis yenilemesinde breadcrumb kaydı
+
+#### Değişti
+- Menü çubuğu ikonu yeni Mimir/Viking tasarımıyla güncellendi
+- İkon uygulama açılışında iki durumda (normal, düşük-kota) önceden oluşturuldu; 60 saniyelik yenileme döngülerinde disk I/O yok
+- Düşük-kota göstergesi kırmızı örtü yerine ikon köşesindeki kırmızı nokta rozetine dönüştürüldü
+- `--csrf_token` bayrak ayrıştırması artık hem boşluklu hem `=` biçimini destekliyor
+
+#### Düzeltildi
+- `lockFocus` 1× bitmap oluşturduğundan Retina ekranlarda menü çubuğu ikonu bulanık görünüyordu — yerel ölçekte render eden ertelenmiş `NSImage` çizim işleyicisiyle değiştirildi
+- Koyu menü çubuklarında ikon zor seçiliyordu — yüksek kontrastlı yeni tasarımla giderildi
+- `contentTintColor` her yenilemede artık açıkça sıfırlanıyor, eski renk kirliliği engellendi
 
 ### [1.1.0] - 2026-05-02
 

--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,15 @@ let package = Package(
     products: [
         .executable(name: "Mimir", targets: ["Mimir"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "9.16.1"),
+    ],
     targets: [
         .executableTarget(
             name: "Mimir",
+            dependencies: [
+                .product(name: "Sentry", package: "sentry-cocoa")
+            ],
             resources: [
                 .copy("Resources")
             ]

--- a/Sources/Mimir/LiveUsageDataSource.swift
+++ b/Sources/Mimir/LiveUsageDataSource.swift
@@ -853,7 +853,8 @@ struct LiveUsageDataSource {
     }
 
     private func extractFlag(_ key: String, from command: String) -> String? {
-        let pattern = "\(NSRegularExpression.escapedPattern(for: key))\\s+([^\\s]+)"
+        // Handles both --key value and --key=value styles
+        let pattern = "\(NSRegularExpression.escapedPattern(for: key))(?:[\\s=]+)([^\\s]+)"
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
         let ns = command as NSString
         let range = NSRange(location: 0, length: ns.length)

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import Sentry
 import SwiftUI
 import UserNotifications
 
@@ -24,9 +25,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var globalEventMonitor: Any?
     private var cancellables: Set<AnyCancellable> = []
     private var lowQuotaNotified: Set<String> = []
+    private var cachedIconNormal: NSImage?
+    private var cachedIconLow: NSImage?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        SentrySDK.start { options in
+            options.dsn = "https://66d3b6b50b79ba45dc89e86329579302@o4511381595291648.ingest.us.sentry.io/4511537599086592"
+            options.debug = true
+            options.sendDefaultPii = true
+            options.tracesSampleRate = 1.0
+        }
+
         NSApp.setActivationPolicy(.accessory)
+
+        if let url = Bundle.main.url(forResource: "AppIcon", withExtension: "png"),
+           let source = NSImage(contentsOf: url) {
+            cachedIconNormal = buildStatusIcon(source: source, isLow: false)
+            cachedIconLow    = buildStatusIcon(source: source, isLow: true)
+        }
 
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             if settings.authorizationStatus == .notDetermined {
@@ -47,11 +63,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         item.button?.action = #selector(togglePopover(_:))
         statusItem = item
 
+        SentrySDK.startProfiler()
         store.refresh()
+        SentrySDK.stopProfiler()
+
         refreshStatusTitle()
         store.$services
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] services in
+                let crumb = Breadcrumb()
+                crumb.category = "services.refresh"
+                crumb.message = services
+                    .map { "\($0.name): \($0.isAvailable ? "ok" : "unavailable")" }
+                    .joined(separator: ", ")
+                crumb.level = services.contains(where: { !$0.isAvailable }) ? .warning : .info
+                SentrySDK.addBreadcrumb(crumb)
                 self?.refreshStatusTitle()
             }
             .store(in: &cancellables)
@@ -126,39 +152,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func refreshStatusTitle() {
-        let iconSize = NSSize(width: 24, height: 24)
-        let image: NSImage
-        if let url = Bundle.main.url(forResource: "AppIcon", withExtension: "png"),
-           let source = NSImage(contentsOf: url) {
-            let canvas = NSImage(size: iconSize)
-            canvas.lockFocus()
-            NSGraphicsContext.current?.imageInterpolation = .high
-            let clip = NSBezierPath(ovalIn: NSRect(origin: .zero, size: iconSize))
-            clip.addClip()
-            source.draw(in: NSRect(origin: .zero, size: iconSize),
-                        from: NSRect(origin: .zero, size: source.size),
-                        operation: .sourceOver, fraction: isQuotaLow ? 0.5 : 1.0)
-            if isQuotaLow {
-                NSColor.systemRed.withAlphaComponent(0.45).setFill()
-                NSBezierPath(ovalIn: NSRect(origin: .zero, size: iconSize)).fill()
-            }
-            canvas.unlockFocus()
-            image = canvas
+        let isLow = isQuotaLow
+        if let icon = isLow ? cachedIconLow : cachedIconNormal {
+            statusItem?.button?.image = icon
         } else {
-            let canvas = NSImage(size: iconSize, flipped: false) { rect in
-                (self.isQuotaLow ? NSColor.systemRed : NSColor.labelColor).setFill()
-                NSBezierPath(ovalIn: rect.insetBy(dx: 1, dy: 1)).fill()
+            let size = NSSize(width: 18, height: 18)
+            let fallback = NSImage(size: size, flipped: false) { [isLow] rect in
+                (isLow ? NSColor.systemRed : NSColor.labelColor).setFill()
+                NSBezierPath(ovalIn: rect.insetBy(dx: 2, dy: 2)).fill()
                 return true
             }
-            image = canvas
+            fallback.isTemplate = false
+            statusItem?.button?.image = fallback
         }
-        image.isTemplate = false
-        statusItem?.button?.image = image
+        statusItem?.button?.contentTintColor = nil
         statusItem?.button?.title = ""
         statusItem?.button?.imagePosition = .imageOnly
-        statusItem?.button?.toolTip = store.services.isEmpty ? "Loading..." : store.services.map(\.name).joined(separator: " | ")
-
+        statusItem?.button?.toolTip = store.services.isEmpty
+            ? "Loading..."
+            : store.services.map(\.name).joined(separator: " | ")
         checkNotifications()
+    }
+
+    private func buildStatusIcon(source: NSImage, isLow: Bool) -> NSImage {
+        let iconSize = NSSize(width: 22, height: 22)
+        let img = NSImage(size: iconSize, flipped: false) { rect in
+            NSGraphicsContext.current?.imageInterpolation = .high
+            source.draw(in: rect, from: NSRect(origin: .zero, size: source.size),
+                        operation: .sourceOver, fraction: 1.0)
+            if isLow {
+                let d: CGFloat = 7
+                NSColor.systemRed.setFill()
+                NSBezierPath(ovalIn: NSRect(x: rect.maxX - d, y: rect.minY, width: d, height: d)).fill()
+            }
+            return true
+        }
+        img.isTemplate = false
+        return img
     }
 
     private var isQuotaLow: Bool {


### PR DESCRIPTION
## Özet

- Sentry SDK 9.16.1 eklendi; çökme, hata ve servis durumu izleme aktif
- Menü çubuğu ikonu yeni Viking/Mimir tasarımıyla değiştirildi
- `lockFocus` kullanımı kaldırıldı — Retina'da bulanık ikon hatası düzeltildi
- İkon startup'ta iki durumda (normal/low-quota) önceden oluşturuluyor; 60s döngüde disk I/O yok
- Düşük kota göstergesi kırmızı overlay yerine ikon köşesindeki nokta badge'e dönüştürüldü
- `extractFlag` regex'i `--key=value` biçimini de destekleyecek şekilde düzeltildi (Antigravity CSRF token)
- `isQuotaLow` çift hesaplama kaldırıldı, `contentTintColor` her refresh'te sıfırlanıyor
- CHANGELOG güncellendi

---
_Generated by [Claude Code](https://claude.ai/code/session_01UELqNJyiFwfzn9pqohLYYB)_