### PR TITLE
security: fix Sentry PII, JSON injection, URL encoding, file permissi…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
 
       - name: Extract version
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        env:
+          REF: ${{ github.ref_name }}
+        run: echo "VERSION=${REF#v}" >> $GITHUB_OUTPUT
 
       - name: Build release
         env:

--- a/Sources/Mimir/LiveUsageDataSource.swift
+++ b/Sources/Mimir/LiveUsageDataSource.swift
@@ -288,8 +288,8 @@ struct LiveUsageDataSource {
         req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.setValue("antigravity/unknown darwin/arm64", forHTTPHeaderField: "User-Agent")
-        let body = projectID.map { "{\"project\":\"\($0)\"}" } ?? "{}"
-        req.httpBody = body.data(using: .utf8)
+        let bodyObj: [String: Any] = projectID.map { ["project": $0] } ?? [:]
+        req.httpBody = try? JSONSerialization.data(withJSONObject: bodyObj)
 
         do {
             let (data, response) = try await URLSession.shared.data(for: req)
@@ -696,6 +696,7 @@ struct LiveUsageDataSource {
             return
         }
         try? data.write(to: state.path, options: .atomic)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: state.path.path)
     }
 
     private func readClaudeToken() -> String? {
@@ -838,7 +839,9 @@ struct LiveUsageDataSource {
     }
 
     private func urlEncode(_ value: String) -> String {
-        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "&=+#")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 
     private func parseISO8601(_ raw: String) -> Date? {

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -31,9 +31,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         SentrySDK.start { options in
             options.dsn = "https://66d3b6b50b79ba45dc89e86329579302@o4511381595291648.ingest.us.sentry.io/4511537599086592"
+            #if DEBUG
             options.debug = true
-            options.sendDefaultPii = true
-            options.tracesSampleRate = 1.0
+            #else
+            options.debug = false
+            #endif
+            options.sendDefaultPii = false
+            options.tracesSampleRate = 0.1
         }
 
         NSApp.setActivationPolicy(.accessory)


### PR DESCRIPTION
…ons, CI shell injection

- Sentry: sendDefaultPii false, tracesSampleRate 0.1, debug only in DEBUG builds
- LiveUsageDataSource: use JSONSerialization for Antigravity request body (JSON injection)
- LiveUsageDataSource: exclude &=+# from urlEncode allowed chars (form param injection)
- LiveUsageDataSource: set 0o600 permissions on codex auth.json after write
- release.yml: pass GITHUB_REF_NAME via env to prevent shell injection in version extraction

https://claude.ai/code/session_01FmCEumQiMYctb9YC6zRpwp