### PR TITLE
fix: dynamic popover height (shrink when fewer cards are shown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+#### Fixed
+- Popover height was locked at its 500pt maximum even when fewer cards were shown (e.g. only Codex running), leaving a large empty area below the branding footer. SwiftUI preference updates were being silently dropped inside the `TimelineView`/`ScrollView` hierarchy, so the height listener never saw the measured value. The popover is now sized directly from the measured content, so it shrinks and grows live as services appear, disappear, or expand their info panel
+
 ### [1.3] - 2026-06-10
 
 #### Added
@@ -125,6 +128,7 @@ sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) k
 - Antigravity kartına, kotanın yerel dil sunucusundan okunduğunu ve verinin güncellenmesi için Antigravity'nin açık olması gerektiğini (kapalıyken son görülen değerlerin gösterildiğini) açıklayan bir (i) bilgi ikonu eklendi
 
 #### Düzeltildi
+- Popover yüksekliği, daha az kart gösterildiğinde bile (örn. yalnızca Codex çalışırken) 500pt'lik üst sınırında sabit kalıyor ve branding footer'ın altında büyük bir boşluk bırakıyordu. SwiftUI preference güncellemeleri `TimelineView`/`ScrollView` hiyerarşisi içinde sessizce düşüyor, bu yüzden yükseklik dinleyicisi ölçülen değeri hiç görmüyordu. Popover artık doğrudan ölçülen içeriğe göre boyutlanıyor; böylece servisler göründükçe, kayboldukça veya bilgi panelini açtıkça canlı olarak küçülüp büyüyor
 - IDE açık olmasına rağmen Antigravity kotası ve reset saati görünmüyordu — `lsof` port aramasında `-a` bayrağı eksikti, bu yüzden `-iTCP`/`-p` filtreleri AND yerine OR'lanıyor ve sistemdeki tüm dinleyen portlar dönüyordu; onlarca yanlış portu denemek 8 saniyelik zaman aşımını patlatıp veriyi boş bırakıyordu. `-a` eklenerek yalnızca dil sunucusunun kendi portları sorgulanıyor
 
 ### [1.2.2] - 2026-06-10

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -63,12 +63,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         popover.behavior = .transient
+        popover.contentSize = NSSize(width: PopoverMetrics.width, height: PopoverMetrics.maxHeight)
+        // Height is driven manually from the measured SwiftUI content (see
+        // onContentHeightChange): preference-based plumbing silently drops
+        // updates inside this TimelineView/ScrollView hierarchy, so the view
+        // reports its size through a plain callback instead.
         let hosting = NSHostingController(
-            rootView: PopoverView(store: store) { [weak self] in
-                self?.closePopover(nil)
-            }
+            rootView: PopoverView(
+                store: store,
+                onDismiss: { [weak self] in self?.closePopover(nil) },
+                onContentHeightChange: { [weak self] height in
+                    guard let self else { return }
+                    let clamped = min(max(height, 80), PopoverMetrics.maxHeight)
+                    guard abs(self.popover.contentSize.height - clamped) > 0.5 else { return }
+                    self.popover.contentSize = NSSize(width: PopoverMetrics.width, height: clamped)
+                }
+            )
         )
-        hosting.sizingOptions = .preferredContentSize
+        hosting.sizingOptions = []
         popover.contentViewController = hosting
 
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
@@ -263,7 +275,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 private struct PopoverView: View {
     @ObservedObject var store: UsageStore
     let onDismiss: () -> Void
-    @State private var contentHeight: CGFloat = PopoverMetrics.maxHeight
+    /// Reports the measured content height so AppKit can size the popover.
+    /// Plain callback on purpose — see the note at the construction site.
+    let onContentHeightChange: (CGFloat) -> Void
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 60)) { context in
@@ -285,7 +299,11 @@ private struct PopoverView: View {
                     .padding(.horizontal, PopoverMetrics.edgeInset)
                     .background {
                         GeometryReader { proxy in
-                            Color.clear.preference(key: PopoverContentHeightKey.self, value: proxy.size.height)
+                            Color.clear
+                                .onAppear { onContentHeightChange(proxy.size.height) }
+                                .onChange(of: proxy.size.height) { _, height in
+                                    onContentHeightChange(height)
+                                }
                         }
                     }
                 }
@@ -306,9 +324,6 @@ private struct PopoverView: View {
                 }
             }
         }
-        .onPreferenceChange(PopoverContentHeightKey.self) { contentHeight = $0 }
-        .frame(width: PopoverMetrics.width)
-        .frame(height: min(contentHeight, PopoverMetrics.maxHeight))
     }
 
     /// Show live services and stale snapshots; hide services that have no data at all.
@@ -396,14 +411,6 @@ private struct BrandingFooter: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.leading, 12)
         .padding(.top, 1)
-    }
-}
-
-private struct PopoverContentHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = PopoverMetrics.maxHeight
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
     }
 }
 


### PR DESCRIPTION
## What

The popover now sizes itself to its actual content instead of staying locked at a fixed 500pt height.

## Why

When fewer service cards were shown (e.g. only Codex running, with Claude/Antigravity absent), the popover kept its full 500pt height — leaving a large empty area below the branding footer.

**Root cause:** height was plumbed through SwiftUI's `PreferenceKey` system, but preference *updates* were silently dropped inside the `TimelineView` → `ScrollView` → `mask` hierarchy. The listener only ever received the default value (500), never the measured one. With 3+ cards this was invisible because `min(measured, 500)` happened to equal 500 anyway; it only surfaced once the content was shorter than the cap.

## How

- Removed the broken `PopoverContentHeightKey` / `onPreferenceChange` plumbing.
- The `GeometryReader`'s measured height now flows through a plain `onContentHeightChange` callback straight to `AppDelegate`, which sets `popover.contentSize` directly (clamped 80–500pt).
- `hosting.sizingOptions` set to `[]` so AppKit doesn't fight the manual sizing.

The popover now resizes live as services appear/disappear or the (i) info panel expands.

## Verification

Tested via a temporary single-service filter (since removed):

| Scenario | Content | Popover | Result |
| --- | --- | --- | --- |
| All services | 522pt | 500pt (capped, scrolls) | ✓ |
| Codex only | 215pt | **215pt** | ✓ (was stuck at 500) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)