### PR TITLE
feat: credit & billing tracking (#8, #9, #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+#### Added
+- Credit & billing tracking ([#8](https://github.com/erayendes/mimir/issues/8), [#9](https://github.com/erayendes/mimir/issues/9), [#10](https://github.com/erayendes/mimir/issues/10)): each service card now surfaces its financial layer when there is one — Antigravity shows the Google One AI credit balance, Codex shows the premium credit balance, and Claude shows pay-as-you-go billing usage (spent / monthly limit). All of it is read from data the existing integrations already fetch (no extra login), the row is omitted for accounts without credits/billing, and the menu-bar low badge also lights when a balance is below its threshold. (Antigravity credit expiry/activity and a dedicated Gemini quota card, [#11](https://github.com/erayendes/mimir/issues/11), are deferred — no reachable data source yet.)
+
 ### [1.6] - 2026-06-15
 
 #### Added
@@ -146,6 +149,9 @@ Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
 
 ### [Yayımlanmadı]
+
+#### Eklendi
+- Kredi & fatura takibi ([#8](https://github.com/erayendes/mimir/issues/8), [#9](https://github.com/erayendes/mimir/issues/9), [#10](https://github.com/erayendes/mimir/issues/10)): her servis kartı, varsa finansal katmanını da gösteriyor — Antigravity Google One AI kredi bakiyesini, Codex premium kredi bakiyesini, Claude ise kullandıkça-öde fatura kullanımını (harcanan / aylık limit). Hepsi mevcut entegrasyonların zaten çektiği veriden okunuyor (ek giriş yok); kredi/fatura olmayan hesaplarda satır gizleniyor ve menü çubuğu düşük rozeti bakiye eşiğin altına düşünce de yanıyor. (Antigravity kredi son-kullanma/aktivitesi ve ayrı bir Gemini kota kartı, [#11](https://github.com/erayendes/mimir/issues/11), erişilebilir kaynak olmadığı için ertelendi.)
 
 ### [1.6] - 2026-06-15
 

--- a/Sources/Mimir/LiveUsageDataSource.swift
+++ b/Sources/Mimir/LiveUsageDataSource.swift
@@ -260,6 +260,9 @@ struct LiveUsageDataSource {
                 resetAt: sonnet.resetAt ?? sevenDay.resetAt
             ))
         }
+        if let billing = claudeBillingRow(root["extra_usage"]) {
+            models.append(billing)
+        }
 
         // Classify by reset time so a window that has already reset (e.g. a 5h reading from an old
         // cache used as a fallback) is blanked rather than shown as if current. Live readings have
@@ -274,6 +277,24 @@ struct LiveUsageDataSource {
 
     private func remainingPercent(fromUsed used: Double) -> Int {
         max(0, min(100, Int((100 - used).rounded())))
+    }
+
+    /// Claude pay-as-you-go billing from the usage API's `extra_usage: { is_enabled, monthly_limit,
+    /// used_credits, utilization, currency }`. Returns nil when not enabled (Pro without overage), so
+    /// the row is omitted — matching the issue's "fall back silently when billing isn't applicable".
+    private func claudeBillingRow(_ raw: Any?) -> ModelStatus? {
+        guard let e = raw as? [String: Any], e["is_enabled"] as? Bool == true else { return nil }
+        let used = doubleValue(e["used_credits"]) ?? 0
+        let limit = doubleValue(e["monthly_limit"])
+        let cur = (e["currency"] as? String).map { $0.uppercased() } ?? ""
+        func money(_ v: Double) -> String {
+            let n = v.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(v)) : String(format: "%.2f", v)
+            return cur.isEmpty ? n : "\(n) \(cur)"
+        }
+        let text = limit.map { "\(money(used)) / \(money($0))" } ?? money(used)
+        let util = doubleValue(e["utilization"]) ?? (limit.map { $0 > 0 ? used / $0 * 100 : 0 } ?? 0)
+        return ModelStatus(name: "Billing", remainingPercent: 0, resetAt: nil,
+                           valueText: text, isLow: util >= 80)
     }
 
     private func fetchCodex() async -> ServiceStatus {
@@ -390,13 +411,28 @@ struct LiveUsageDataSource {
                 weeklyResetAt: weekly.resetAt,
                 sessionRemainingPercent: session.usedPercent.map(remainingPercent(fromUsed:)) ?? 100,
                 weeklyRemainingPercent: weekly.usedPercent.map(remainingPercent(fromUsed:)) ?? 100,
-                models: [],
+                models: codexCreditRow(root["credits"]).map { [$0] } ?? [],
                 isAvailable: true,
                 statusNote: "chatgpt usage api"
             )
         } catch {
             return nil
         }
+    }
+
+    /// Codex premium credit balance from `wham/usage` `credits: { has_credits, unlimited, balance }`.
+    /// Returns nil for free/Plus accounts with no credits, so the row is simply omitted.
+    private func codexCreditRow(_ raw: Any?) -> ModelStatus? {
+        guard let c = raw as? [String: Any] else { return nil }
+        if c["unlimited"] as? Bool == true {
+            return ModelStatus(name: "Credits", remainingPercent: 0, resetAt: nil, valueText: "Unlimited")
+        }
+        guard c["has_credits"] as? Bool == true else { return nil }
+        let amount = (c["balance"] as? String).flatMap(Double.init) ?? doubleValue(c["balance"]) ?? 0
+        guard amount > 0 else { return nil }
+        let text = amount.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(amount)) : String(amount)
+        return ModelStatus(name: "Credits", remainingPercent: 0, resetAt: nil,
+                           valueText: "\(text) credits", isLow: amount < 5)
     }
 
     private func fetchAntigravity() async -> ServiceStatus {
@@ -674,9 +710,12 @@ struct LiveUsageDataSource {
             return nil
         }
 
-        let models = antigravityQuotaSummaryRows(groups: groups)
+        var models = antigravityQuotaSummaryRows(groups: groups)
         guard !models.isEmpty else {
             return nil
+        }
+        if let credit = antigravityCreditRow(csrf: csrf, ports: ports) {
+            models.append(credit)
         }
         return ServiceStatus(
             name: "Antigravity",
@@ -687,6 +726,36 @@ struct LiveUsageDataSource {
             isAvailable: true,
             statusNote: "quota summary"
         )
+    }
+
+    /// Google One AI credit balance from Antigravity's GetUserStatus (`userTier.availableCredits`),
+    /// shown alongside the quota rows. `creditAmount`/`minimumCreditAmountForUsage` are JSON strings.
+    private func antigravityCreditRow(csrf: String, ports: [Int]) -> ModelStatus? {
+        let body = "{\"metadata\":{\"ideName\":\"antigravity\",\"locale\":\"en\"}}"
+        func num(_ raw: Any?) -> Double? { (raw as? String).flatMap(Double.init) ?? doubleValue(raw) }
+        for p in ports {
+            let out = runCommand("/usr/bin/curl", [
+                "-ks", "--max-time", "2",
+                "-H", "X-Codeium-Csrf-Token: \(csrf)",
+                "-H", "Connect-Protocol-Version: 1",
+                "-H", "Content-Type: application/json",
+                "--data", body,
+                "https://127.0.0.1:\(p)/exa.language_server_pb.LanguageServerService/GetUserStatus"
+            ])
+            guard let data = out.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let userStatus = json["userStatus"] as? [String: Any],
+                  let tier = userStatus["userTier"] as? [String: Any],
+                  let credits = tier["availableCredits"] as? [[String: Any]], !credits.isEmpty else {
+                continue
+            }
+            let one = credits.first { ($0["creditType"] as? String)?.contains("GOOGLE_ONE") == true } ?? credits[0]
+            guard let amount = num(one["creditAmount"]) else { return nil }
+            let minimum = num(one["minimumCreditAmountForUsage"]) ?? 0
+            return ModelStatus(name: "Google One credits", remainingPercent: 0, resetAt: nil,
+                               valueText: String(Int(amount)), isLow: amount < minimum)
+        }
+        return nil
     }
 
     /// Flatten `groups[].buckets[]` into one row per (group × window), ordered 5h then
@@ -1197,8 +1266,8 @@ struct LiveUsageDataSource {
     /// to the same store so Claude Code's own login keeps working (Anthropic rotates the refresh
     /// token, so persisting it is mandatory). Returns the new access token, or nil on any failure.
     private func refreshClaudeToken() async -> String? {
-        guard var (root, source) = readClaudeCredential(),
-              var oauth = root["claudeAiOauth"] as? [String: Any],
+        guard let credential = readClaudeCredential(),
+              var oauth = credential.root["claudeAiOauth"] as? [String: Any],
               let refresh = oauth["refreshToken"] as? String, !refresh.isEmpty else {
             return nil
         }
@@ -1226,8 +1295,9 @@ struct LiveUsageDataSource {
         if let expiresIn = doubleValue(resp["expires_in"]) {
             oauth["expiresAt"] = Int(Date().timeIntervalSince1970 * 1000 + expiresIn * 1000)
         }
+        var root = credential.root
         root["claudeAiOauth"] = oauth
-        writeClaudeCredential(root, to: source)
+        writeClaudeCredential(root, to: credential.source)
         return newAccess
     }
 

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -232,9 +232,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var isQuotaLow: Bool {
         store.services.filter(\.isAvailable).contains { svc in
+            // Percentage windows + percentage model rows (skip valueText rows — a credit balance
+            // isn't a 0–100 percent, and its `remainingPercent` is a placeholder 0).
             let percents: [Int?] = [svc.sessionRemainingPercent, svc.weeklyRemainingPercent]
-                + svc.models.map { Optional($0.remainingPercent) }
-            return percents.compactMap { $0 }.contains { $0 < 20 }
+                + svc.models.filter { $0.valueText == nil }.map { Optional($0.remainingPercent) }
+            if percents.compactMap({ $0 }).contains(where: { $0 < 20 }) { return true }
+            // Credit/billing rows flag themselves via `isLow` (below their own threshold).
+            return svc.models.contains { $0.isLow }
         }
     }
 

--- a/Sources/Mimir/MimirModels.swift
+++ b/Sources/Mimir/MimirModels.swift
@@ -98,12 +98,17 @@ struct ModelStatus: Identifiable {
     let remainingPercent: Int
     let resetAt: Date?
     let valueText: String?
+    /// For a `valueText` row (e.g. a credit balance) whose level isn't a 0–100 percent: set true
+    /// when it's below its threshold, so the menu-bar low-quota badge can trigger on it. Percentage
+    /// rows leave this false and are judged by `remainingPercent` instead.
+    let isLow: Bool
 
-    init(name: String, remainingPercent: Int, resetAt: Date?, valueText: String? = nil) {
+    init(name: String, remainingPercent: Int, resetAt: Date?, valueText: String? = nil, isLow: Bool = false) {
         self.name = name
         self.remainingPercent = remainingPercent
         self.resetAt = resetAt
         self.valueText = valueText
+        self.isLow = isLow
     }
 }
 


### PR DESCRIPTION
Surfaces each service's financial layer in its existing popover card — all from data the integrations **already fetch** (no new logins, no extra setup). Closes the implementable parts of the 💳 Credit Tracking milestone.

## What's added

| Issue | Service | Data | Source |
|---|---|---|---|
| #8 | Antigravity | Google One AI credit balance (e.g. `863`) | GetUserStatus `userTier.availableCredits` (one extra RPC on the same language server) |
| #9 | Codex | Premium credit balance | `wham/usage` → `credits` block |
| #10 | Claude | Pay-as-you-go billing (spent / monthly limit) | usage API `extra_usage` block |

- Credits render as `ModelStatus` `valueText` rows — **no view change**; snapshot/staleness/cooldown persist them automatically.
- New `ModelStatus.isLow` lets a below-threshold balance light the menu-bar low badge; `isQuotaLow` now excludes `valueText` rows from its percentage check so a credit row's placeholder `0%` can't falsely turn the icon red.
- Rows are **omitted** for accounts without credits/billing (free tier, billing disabled) — graceful, no clutter.

## Verified

- Debug + release builds clean.
- Live: the Antigravity card shows `Google One credits 863` alongside its quota rows. Codex/Claude rows are correctly omitted on an account with no credits / `extra_usage` disabled (graceful path).

## Deferred (no reachable data source)

Research this session confirmed these are blocked by a browser-session wall, not local OAuth:

- **#8 extras** — Antigravity credit **expiry date** + per-session **activity log** need a Google One cloud API we don't have a token for.
- **#11 Gemini card** — the gemini.google.com consumer quota is a **separate pool** from Antigravity (verified empirically by burning Antigravity's Gemini quota with no change to gemini.google.com) and is only exposed behind a Google web session (`aistudio.google.com` dashboard / `batchexecute`), not an OAuth endpoint.
- **ChatGPT chat-product limits** — `chatgpt.com/backend-api/*` chat endpoints return 403 (Cloudflare) to a token request; only the Codex-side `wham/usage` is reachable (already shown on the Codex card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)