### PR TITLE
ci: bump checkout/cache actions to v5 for native Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,9 @@ jobs:
     permissions:
       contents: write
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       SIGN_IDENTITY: "Developer ID Application: Eray Endes (926AC5V2UG)"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -25,7 +24,7 @@ jobs:
         run: echo "VERSION=${REF#v}" >> "$GITHUB_OUTPUT"
 
       - name: Cache SwiftPM
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .build


### PR DESCRIPTION
actions/checkout@v4 and actions/cache@v4 run on Node 20, which GitHub is deprecating, forcing the runner onto Node 24 and emitting a deprecation annotation. Bump both to v5 (native Node 24) and drop the now-redundant FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 workaround.


Claude-Session: https://claude.ai/code/session_015794ntCRENRvqiNgN3DJSZ