### PR TITLE
Fix Antigravity session quota display

### DIFF
--- a/Sources/Mimir/AntigravityProvider.swift
+++ b/Sources/Mimir/AntigravityProvider.swift
@@ -342,7 +342,7 @@ extension LiveUsageDataSource {
         }).first else {
             return ModelStatus(name: name, remainingPercent: 0, resetAt: nil)
         }
-        return ModelStatus(name: name, remainingPercent: best.remainingPercent, resetAt: best.resetAt)
+        return ModelStatus(name: name, remainingPercent: best.remainingPercent, resetAt: best.resetAt, window: .session)
     }
     private func readAntigravityCockpitAccount() -> [String: Any]? {
         let path = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".antigravity_cockpit/credentials.json")

--- a/Sources/Mimir/PopoverViews.swift
+++ b/Sources/Mimir/PopoverViews.swift
@@ -351,7 +351,7 @@ struct ServiceCard: View {
             switch model.window {
             case .session: sessions[model.name] = (model.remainingPercent, model.resetAt)
             case .weekly:  weeklies[model.name] = (model.remainingPercent, model.resetAt)
-            case .none:    break
+            case .none:    sessions[model.name] = (model.remainingPercent, model.resetAt)
             }
         }
         return order.map { name in


### PR DESCRIPTION
## What

Fixes Antigravity quota display by preserving the session window when creating the selected model status, and by treating statuses without an explicit window as session entries in the popover grouping.

## Verification

- `swift build`