### PR TITLE
fix: skip Sparkle updater for dev builds to prevent error dialog

### DIFF
--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -106,11 +106,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: nil,
-            userDriverDelegate: nil
-        )
+        // Dev builds have no Sparkle feed — skip the updater to avoid the
+        // "Unable to Check For Updates" error dialog at launch.
+        if !isDevBuild {
+            updaterController = SPUStandardUpdaterController(
+                startingUpdater: true,
+                updaterDelegate: nil,
+                userDriverDelegate: nil
+            )
+        }
 
         NSApp.setActivationPolicy(.accessory)
 
@@ -255,10 +259,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(toggle)
         menu.addItem(.separator())
 
-        let update = NSMenuItem(title: String(localized: "Check for updates"),
-                                action: #selector(menuCheckForUpdates), keyEquivalent: "")
-        update.target = self
-        menu.addItem(update)
+        if updaterController != nil {
+            let update = NSMenuItem(title: String(localized: "Check for updates"),
+                                    action: #selector(menuCheckForUpdates), keyEquivalent: "")
+            update.target = self
+            menu.addItem(update)
+        }
 
         let quit = NSMenuItem(title: String(localized: "Quit Mimir"),
                               action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")


### PR DESCRIPTION
## Problem

Dev builds (`com.erayendes.mimir.dev`) have no Sparkle feed (`appcast.xml`) configured — the `build_and_run.sh` script intentionally omits the version string and update feed. However, `SPUStandardUpdaterController` was still initialized with `startingUpdater: true`, causing an **"Unable to Check For Updates"** error dialog to appear at launch.

## Fix

Gate the Sparkle updater behind the existing `isDevBuild` check (already used for Sentry):

1. **Skip updater initialization** for dev builds — `updaterController` stays `nil`
2. **Hide the "Check for updates" menu item** when `updaterController` is nil

This is a minimal, surgical change — the `isDevBuild` variable was already computed at line 74 for the Sentry gate, so no new logic is introduced.

## Testing

- Dev build (`./script/build_and_run.sh install`): no error dialog, no "Check for updates" in right-click menu
- Production build path is unaffected (the `isDevBuild` guard is not taken)

```diff
-        updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: nil,
-            userDriverDelegate: nil
-        )
+        if !isDevBuild {
+            updaterController = SPUStandardUpdaterController(
+                startingUpdater: true,
+                updaterDelegate: nil,
+                userDriverDelegate: nil
+            )
+        }
```