### PR TITLE
fix(sentry): stop reporting upstream 5xx as errors (MIMIR-3)

### DIFF
--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -101,6 +101,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // so it fires false positives whenever a modal is open (MIMIR-4/5/6/7).
                 // Crash and error reporting stay on.
                 options.enableAppHangTracking = false
+                // We poll third-party usage APIs (chatgpt.com, claude.ai) every minute;
+                // their transient 5xx are expected and handled by the next poll's retry.
+                // Sentry's auto HTTP-failure capture turned every one into an error
+                // (MIMIR-3: 885 events of a 503 from chatgpt.com/backend-api/wham/usage).
+                options.enableCaptureFailedRequests = false
             }
         }
 


### PR DESCRIPTION
## Problem

Sentry's `enableCaptureFailedRequests` (default `true` since SDK v8) turns every failed HTTP request into an error event. Mimir polls third-party usage APIs every minute, so each transient upstream outage became a reported error.

MIMIR-3: **885 occurrences, 17 users** — all one 503 from `chatgpt.com/backend-api/wham/usage`. No bug on our side; the next poll retries and the user never notices. The issue was archived-forever to silence it, but the source stayed on and could escalate again on a new release.

## Fix

Disable the auto HTTP-failure capture. Crash and manual error reporting stay on.

This is the third tracker disabled for the same reason — `enableAutoBreadcrumbTracking` (MIMIR-2) and `enableAppHangTracking` (MIMIR-4/5/6/7) — and follows the same comment pattern.

## Test

`swift test` — 78 tests green. No behavior change beyond what Sentry reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)