### PR TITLE
fix(codex): harden window classification against API shape drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Internal
 - Every push and pull request now builds the app and the widget and runs the tests on macOS.
+- Codex quota windows are now recognised by how far their reset is when the API leaves out the window length, and either spelling of the reset field is accepted — so another change to OpenAI's payload can't quietly bring the mislabelled window back.
+- Transient outages from the providers' usage APIs are no longer filed as app errors.
 
 ### [2.6] - 2026-07-09
 
@@ -384,6 +386,8 @@ sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) k
 
 #### Dahili
 - Her push ve pull request'te uygulama ve widget macOS'ta derlenip testler çalıştırılıyor.
+- Codex kota pencereleri, API pencere uzunluğunu göndermediğinde sıfırlanma uzaklığından tanınıyor ve sıfırlanma alanının iki yazımı da kabul ediliyor — böylece OpenAI'nin verisindeki yeni bir değişiklik yanlış etiketlenen pencereyi sessizce geri getiremiyor.
+- Sağlayıcıların kullanım API'lerindeki geçici kesintiler artık uygulama hatası olarak kaydedilmiyor.
 
 ### [2.6] - 2026-07-09
 

--- a/Sources/Mimir/CodexProvider.swift
+++ b/Sources/Mimir/CodexProvider.swift
@@ -40,15 +40,16 @@ extension LiveUsageDataSource {
             // Classify each window by its real length, not its slot (see codexStatus): a window of
             // <= 6h is the 5-hour session, anything longer is the weekly one. Since July 2026 the
             // sole window OpenAI returns can be the weekly one (window_minutes 10080), so "primary"
-            // no longer implies "5-hour". Missing window_minutes → fall back to the slot.
+            // no longer implies "5-hour".
+            let now = Date()
             for (w, slotIsPrimary) in [(rl.primary, true), (rl.secondary, false)] {
-                guard let w, let summary = summarizeCodexWindow(w, now: Date()) else { continue }
-                let isSession = w.window_minutes.map { $0 <= 360 } ?? slotIsPrimary
-                if isSession {
-                    if sessionRemaining == nil {
-                        sessionRemaining = remainingPercent(fromUsed: summary.usedPercent)
-                        sessionReset = summary.resetAt
-                    }
+                guard let w, let summary = summarizeCodexWindow(w, now: now) else { continue }
+                let isSession = codexWindowIsSession(periodSeconds: w.window_minutes.map { Double($0) * 60 },
+                                                     resetAt: summary.resetAt,
+                                                     slotIsPrimary: slotIsPrimary, now: now)
+                if isSession, sessionRemaining == nil {
+                    sessionRemaining = remainingPercent(fromUsed: summary.usedPercent)
+                    sessionReset = summary.resetAt
                 } else if weeklyRemaining == nil {
                     weeklyRemaining = remainingPercent(fromUsed: summary.usedPercent)
                     weeklyReset = summary.resetAt
@@ -125,9 +126,9 @@ extension LiveUsageDataSource {
     /// temporarily removed Codex's 5-hour limit in July 2026, so the sole window it now returns can be
     /// the WEEKLY one sitting in the `primary_window` slot (limit_window_seconds 604800) — "primary" no
     /// longer implies "5-hour". A window of <= 6h is the 5-hour session, anything longer is the weekly
-    /// one; when the period field is missing, fall back to the slot. An absent window stays nil (no
-    /// misleading "100%"). If the 5h window returns later, it's classified as the session again.
-    func codexStatus(fromUsageRoot root: [String: Any]) -> ServiceStatus {
+    /// one; see `codexWindowIsSession` for what happens when the period field is missing. An absent
+    /// window stays nil (no misleading "100%"). If the 5h window returns later, it's the session again.
+    func codexStatus(fromUsageRoot root: [String: Any], now: Date = Date()) -> ServiceStatus {
         let rateLimit = root["rate_limit"] as? [String: Any] ?? [:]
 
         var session: (percent: Int, resetAt: Date?)?
@@ -136,9 +137,13 @@ extension LiveUsageDataSource {
             guard let obj = raw as? [String: Any] else { continue }
             let window = codexAPIWindow(obj)
             let percent = window.usedPercent.map(remainingPercent(fromUsed:)) ?? 100
-            let isSession = doubleValue(obj["limit_window_seconds"]).map { $0 <= 6 * 3600 } ?? slotIsPrimary
-            if isSession {
-                if session == nil { session = (percent, window.resetAt) }
+            let isSession = codexWindowIsSession(periodSeconds: doubleValue(obj["limit_window_seconds"]),
+                                                 resetAt: window.resetAt,
+                                                 slotIsPrimary: slotIsPrimary, now: now)
+            // A second window that also reads as the session lands in the weekly slot rather than
+            // being dropped — better a slightly mislabelled reading than a missing one.
+            if isSession, session == nil {
+                session = (percent, window.resetAt)
             } else if weekly == nil {
                 weekly = (percent, window.resetAt)
             }
@@ -197,8 +202,22 @@ extension LiveUsageDataSource {
         }
 
         let used = doubleValue(obj["used_percent"])
-        let reset = doubleValue(obj["reset_at"]).map { Date(timeIntervalSince1970: $0) }
-        return (used, reset)
+        // The reset epoch has appeared under both spellings across Codex surfaces (`reset_at` in the
+        // usage API, `resets_at` in the session files), so accept either rather than silently losing
+        // the countdown if this response switches.
+        let resetEpoch = doubleValue(obj["reset_at"]) ?? doubleValue(obj["resets_at"])
+        return (used, resetEpoch.map { Date(timeIntervalSince1970: $0) })
+    }
+
+    /// Is this rate-limit window the 5-hour session (vs the weekly one)? Decided by the window's real
+    /// PERIOD — "primary" no longer implies "5-hour" (see `codexStatus`). The period field is the only
+    /// reliable signal, so when it's absent fall back to how far the reset is: a 5-hour window can
+    /// never reset more than 5h out. That fallback misreads a weekly window in its final hours, which
+    /// is still better than trusting the slot; the slot is the last resort.
+    func codexWindowIsSession(periodSeconds: Double?, resetAt: Date?, slotIsPrimary: Bool, now: Date) -> Bool {
+        if let periodSeconds { return periodSeconds <= 6 * 3600 }
+        if let resetAt, resetAt > now { return resetAt.timeIntervalSince(now) <= 8 * 3600 }
+        return slotIsPrimary
     }
 
     private func readCodexAuthState() -> CodexAuthState? {

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -44,6 +44,11 @@ final class UsageParsingTests: XCTestCase {
         let (none, noReset) = ds.codexAPIWindow(nil)
         XCTAssertNil(none)
         XCTAssertNil(noReset)
+
+        // The session files spell it `resets_at`; accept either so a shape change can't silently
+        // drop the countdown.
+        let (_, plural) = ds.codexAPIWindow(["used_percent": 5.0, "resets_at": 1_700_000_000.0])
+        XCTAssertEqual(plural, Date(timeIntervalSince1970: 1_700_000_000))
     }
 
     /// The real Plus case since OpenAI's July 2026 5-hour removal: the sole window sits in the
@@ -79,8 +84,8 @@ final class UsageParsingTests: XCTestCase {
         XCTAssertEqual(status.sessionResetAt, Date(timeIntervalSince1970: 1_700_000_000))
     }
 
-    /// No duration field (legacy shape) → fall back to the slot: primary is the session, secondary
-    /// the weekly. Keeps older payloads working unchanged.
+    /// No duration field and the resets already lapsed → nothing better to go on, so fall back to the
+    /// slot: primary is the session, secondary the weekly. Keeps older payloads working unchanged.
     func testCodexStatusFallsBackToSlotWhenNoDuration() {
         let root: [String: Any] = [
             "rate_limit": [
@@ -91,6 +96,42 @@ final class UsageParsingTests: XCTestCase {
         let status = ds.codexStatus(fromUsageRoot: root)
         XCTAssertEqual(status.sessionRemainingPercent, 80)
         XCTAssertEqual(status.weeklyRemainingPercent, 40)
+    }
+
+    /// The period field is the only reliable signal; when it goes missing, how far the reset is beats
+    /// the slot. Here the sole window resets 6 DAYS out while sitting in `primary_window` — the shape
+    /// that made Mimir print "5s, resets in 6d". Without a duration it must still read as weekly.
+    func testCodexStatusUsesResetDistanceWhenDurationMissing() {
+        let now = Date(timeIntervalSince1970: 1_785_000_000)
+        let root: [String: Any] = [
+            "rate_limit": [
+                "primary_window": ["used_percent": 1.0, "reset_at": now.addingTimeInterval(6 * 86400).timeIntervalSince1970],
+            ]
+        ]
+        let status = ds.codexStatus(fromUsageRoot: root, now: now)
+        XCTAssertNil(status.sessionRemainingPercent)          // not a 5h window
+        XCTAssertEqual(status.weeklyRemainingPercent, 99)
+
+        // A reset within 5h can only be the session window.
+        let soon: [String: Any] = [
+            "rate_limit": ["primary_window": ["used_percent": 10.0, "reset_at": now.addingTimeInterval(2 * 3600).timeIntervalSince1970]]
+        ]
+        XCTAssertEqual(ds.codexStatus(fromUsageRoot: soon, now: now).sessionRemainingPercent, 90)
+    }
+
+    /// Both windows read as the session (no duration, both resetting soon): the second must land in
+    /// the weekly slot instead of being dropped — a slightly mislabelled reading beats a missing one.
+    func testCodexStatusKeepsSecondWindowWhenBothLookLikeSession() {
+        let now = Date(timeIntervalSince1970: 1_785_000_000)
+        let root: [String: Any] = [
+            "rate_limit": [
+                "primary_window": ["used_percent": 20.0, "reset_at": now.addingTimeInterval(3600).timeIntervalSince1970],
+                "secondary_window": ["used_percent": 60.0, "reset_at": now.addingTimeInterval(2 * 3600).timeIntervalSince1970],
+            ]
+        ]
+        let status = ds.codexStatus(fromUsageRoot: root, now: now)
+        XCTAssertEqual(status.sessionRemainingPercent, 80)
+        XCTAssertEqual(status.weeklyRemainingPercent, 40)     // kept, not dropped
     }
 
     /// No `primary_window` — the common case since OpenAI temporarily removed Codex's 5-hour limit in


### PR DESCRIPTION
## Problem

Classifying a Codex rate-limit window by its real period is only as good as the period field. Two ways that broke silently:

1. **Missing period → slot fallback.** Since July 2026 the weekly window can sit in `primary_window`, so trusting the slot reproduces the original bug: `"5s, resets in 6d"`.
2. **Single reset-key spelling.** The reset epoch is `reset_at` in the usage API but `resets_at` in the session files. We read only the former, so a shape change would silently drop the countdown.

Neither fires today — this is forward-proofing against OpenAI changing the payload again, which is exactly what caused the 2.7 bug.

## Fix

- New shared `codexWindowIsSession(periodSeconds:resetAt:slotIsPrimary:now:)` — classification ordered by how trustworthy the evidence is: real period → reset distance (a 5-hour window can never reset more than 5h out) → slot as last resort.
- `codexAPIWindow` accepts `reset_at` or `resets_at`.
- Both call sites (usage API + local session files) now share the helper instead of repeating the rule.
- A second window that also reads as the session lands in the weekly slot rather than being dropped — a slightly mislabelled reading beats a missing one.

## Test

`swift test` — 78 green (76 before). Three new cases: reset-distance fallback in both directions, the `resets_at` spelling, and the both-look-like-session corner. Existing slot-fallback test unchanged and still passing.

Origin: a local commit of Eray's (`d04edd6`) that solved the same problem in parallel with what shipped on main; these are the two hardenings his version had that main's didn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)