### PR TITLE
ci(release): verify sentry-cli instead of piping a remote script to bash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,17 @@ updates:
       actions:
         patterns:
           - "*"
+
+  # Sparkle verifies and installs the app's own updates, so a flaw in it is a flaw in
+  # Mimir's update path — worth hearing about. Nothing was watching these before: the
+  # dependency graph only picked up the workflow actions, not Package.resolved.
+  - package-ecosystem: swift
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: chore
+    groups:
+      swift:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,12 +107,22 @@ jobs:
           xcrun stapler staple dist/Mimir.app
           rm -f /tmp/mimir_notarize.zip /tmp/AuthKey.p8
 
+      # Fetch the sentry-cli binary at a pinned version and verify its digest before running it.
+      # The old `curl https://sentry.io/get-cli/ | bash` piped a live remote script straight into a
+      # shell that holds the Developer ID certificate and the Sparkle signing key. The universal
+      # build runs on either runner architecture. To bump: change SENTRY_CLI_VERSION and replace
+      # the digest with the new release's (shasum -a 256 on the downloaded file).
       - name: Upload dSYM to Sentry
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_CLI_VERSION: "2.46.0"
+          SENTRY_CLI_SHA256: "8b90c89cbff071230457b80344c6ac7a1d04a76debefb6d702b4509605beba23"
         run: |
-          curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.46.0 bash
-          sentry-cli debug-files upload --org milowda --project mimir "dist/Mimir.app.dSYM"
+          curl -fsSL --retry 3 -o /tmp/sentry-cli \
+            "https://github.com/getsentry/sentry-cli/releases/download/${SENTRY_CLI_VERSION}/sentry-cli-Darwin-universal"
+          echo "$SENTRY_CLI_SHA256  /tmp/sentry-cli" | shasum -a 256 -c -
+          chmod +x /tmp/sentry-cli
+          /tmp/sentry-cli debug-files upload --org milowda --project mimir "dist/Mimir.app.dSYM"
 
       # Zip the *stapled* app. The asset MUST be named Mimir.zip — the appcast
       # enclosure URL points at .../v${VERSION}/Mimir.zip.


### PR DESCRIPTION
The last open Pinned-Dependencies alert (#9), and the one that mattered most of the set.

## Problem

```
curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.46.0 bash
```

`SENTRY_CLI_VERSION` pinned *what the script installed*, not the script. The installer was fetched live on every release and piped straight into a shell — one that has the Developer ID certificate, the notarization key and the **Sparkle signing key** in scope. Anyone able to change what that endpoint serves could sign updates as Mimir.

## Fix

Download the release binary at a pinned version from GitHub and verify its SHA-256 before executing it. A swapped artifact fails `shasum -c` and the build stops instead of running with the secrets available.

`sentry-cli-Darwin-universal` runs on either runner architecture, so there's no arch guess to get wrong.

Dependabot does not track raw downloads, so the comment above the step spells out how to bump it: change the version, replace the digest.

## Test

Ran the exact command sequence locally: download succeeds, `shasum -c` reports OK, `sentry-cli --version` prints `2.46.0`. Appending a byte to the binary makes `shasum -c` fail, so the guard stops the build rather than running a modified binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)