### PR TITLE
docs: correct the download format, the privacy claims and stale behaviour

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -30,11 +30,15 @@ Please include:
 
 #### Scope
 
-This app runs entirely locally and sends no data over the network. Security concerns typically relate to:
+The app runs on your machine and has no backend of its own, but it is not offline: it
+calls each provider's own usage endpoint with that provider's own token, and sends crash
+and anonymous usage telemetry. See [Privacy & Security](../docs/PRIVACY.md) for the full
+list. Security concerns typically relate to:
 
 - Local file access (`~/.claude`, `~/.codex`, etc.)
-- macOS Keychain read operations
-- Antigravity / Gemini API token handling
+- macOS Keychain read operations, and reading the Claude desktop app's session cookie
+- Token handling for the Anthropic, ChatGPT and Google Cloud Code endpoints
+- The release pipeline (signing, notarization, the Sparkle update feed)
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -15,8 +15,8 @@
 
 ### Option 1 — Download a release (recommended)
 
-1. Grab the latest `.dmg` from the [Releases](https://github.com/erayendes/mimir/releases) page.
-2. Open the `.dmg` and drag **Mimir.app** into your **Applications** folder.
+1. Grab the latest `Mimir.zip` from the [Releases](https://github.com/erayendes/mimir/releases) page.
+2. Unzip it and drag **Mimir.app** into your **Applications** folder.
 3. Launch Mimir — the Mimir icon appears in the menu bar.
 
 > ℹ️ **Notarized** — Distributed releases are notarized by Apple, so you won't get a Gatekeeper warning. (Releases are signed and notarized entirely on CI.)
@@ -51,7 +51,7 @@ For services to appear, you must have signed in to each AI tool at least once (M
 
 ### Updating
 
-Mimir updates itself via **Sparkle**. Use **Check for Updates** from the popover menu, or download the new `.dmg` from the Releases page.
+Mimir updates itself via **Sparkle**. Use **Check for Updates** from the popover menu, or download the new `Mimir.zip` from the Releases page.
 
 Stuck on something? → [Support & FAQ](../.github/SUPPORT.md). Otherwise → **[Services](SERVICES.md)**.
 
@@ -66,8 +66,8 @@ Stuck on something? → [Support & FAQ](../.github/SUPPORT.md). Otherwise → **
 
 ### Seçenek 1 — Hazır sürümü indir (önerilen)
 
-1. [Releases](https://github.com/erayendes/mimir/releases) sayfasından en güncel `.dmg` dosyasını indirin.
-2. `.dmg`'yi açın ve **Mimir.app**'i **Uygulamalar** klasörünüze sürükleyin.
+1. [Releases](https://github.com/erayendes/mimir/releases) sayfasından en güncel `Mimir.zip` dosyasını indirin.
+2. Arşivi açın ve **Mimir.app**'i **Uygulamalar** klasörünüze sürükleyin.
 3. Mimir'i çalıştırın — menü çubuğunda Mimir ikonu belirir.
 
 > ℹ️ **Notarize edilmiştir** — Dağıtılan sürümler Apple tarafından notarize edilir; Gatekeeper uyarısı almazsınız. (Sürümler tamamen CI üzerinde imzalanıp notarize edilir.)
@@ -102,6 +102,6 @@ Mimir ilk açıldığında, **oturum açıldığında otomatik başlatma** (Laun
 
 ### Güncelleme
 
-Mimir, **Sparkle** ile kendi içinden güncellenir. Açılır penceredeki menüden **Güncellemeleri Denetle**'yi kullanabilir veya yeni `.dmg`'yi Releases sayfasından indirebilirsiniz.
+Mimir, **Sparkle** ile kendi içinden güncellenir. Açılır penceredeki menüden **Güncellemeleri Denetle**'yi kullanabilir veya yeni `Mimir.zip` dosyasını Releases sayfasından indirebilirsiniz.
 
 Takıldığınız bir nokta olursa → [Destek & SSS](../.github/SUPPORT.md). Kurulum tamamsa → **[Servisler](SERVICES.md)**.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -18,6 +18,8 @@ Mimir reads only **local** sources:
 
 - The AI tools' config/log files: `~/.claude`, `~/.codex`, etc.
 - Entries in the macOS **Keychain** created by the respective apps (tokens).
+- The **Claude desktop app's** session cookie, decrypted with the same macOS Keychain key
+  the app itself uses — this is what gives Claude's live reading.
 
 This is data your tools **already** create on your machine; Mimir only reads it.
 
@@ -29,7 +31,16 @@ Mimir only makes requests to each service's **own official endpoint**, with **th
 - The ChatGPT usage API for Codex
 - Google Cloud Code authorized endpoints for Antigravity
 
-These requests are the same kind the tool itself would make. **Mimir inserts no server of its own** and relays data to no third party.
+These requests are the same kind the tool itself would make. **Mimir inserts no server of its own**, and your quota figures and tokens are relayed to no one.
+
+Two services do receive data, and neither gets anything about your usage:
+
+| Service | What it receives | Control |
+|---|---|---|
+| **Sentry** | Crash and error reports — technical app health only | Always on in released builds |
+| **TelemetryDeck** | Anonymous, categorical signals: which providers are in use (a yes/no, never a value) and how many widgets are placed | Opt-out from the popover menu |
+
+No quota percentages, reset times, credit balances, account ids or tokens are ever sent to either. Development builds send nothing at all.
 
 ### Token handling
 
@@ -61,6 +72,8 @@ Mimir yalnızca **yerel** kaynakları okur:
 
 - AI araçlarının yapılandırma/log dosyaları: `~/.claude`, `~/.codex` vb.
 - macOS **Keychain**'de ilgili uygulamaların oluşturduğu kayıtlar (token'lar).
+- **Claude masaüstü uygulamasının** oturum çerezi; uygulamanın kendi kullandığı macOS
+  Keychain anahtarıyla çözülür — Claude'un canlı okumasını sağlayan kaynak budur.
 
 Bu veriler, kullandığınız araçların makinenizde **zaten** oluşturduğu verilerdir; Mimir bunları sadece okur.
 
@@ -72,7 +85,16 @@ Mimir yalnızca, ilgili servisin **kendi resmî uç noktasına**, **o servisin k
 - Codex için ChatGPT kullanım API'si
 - Antigravity için Google Cloud Code yetkili uç noktaları
 
-Bu istekler, aracın kendisinin yapacağı isteklerle aynı niteliktedir. **Mimir araya kendi sunucusunu sokmaz**, veriyi hiçbir üçüncü tarafa iletmez.
+Bu istekler, aracın kendisinin yapacağı isteklerle aynı niteliktedir. **Mimir araya kendi sunucusunu sokmaz**; kota bilgileriniz ve token'larınız hiç kimseye iletilmez.
+
+İki servis veri alır, ikisi de kullanımınıza dair hiçbir şey görmez:
+
+| Servis | Ne alır | Denetim |
+|---|---|---|
+| **Sentry** | Çökme ve hata raporları — yalnızca uygulamanın teknik sağlığı | Yayınlanan sürümlerde her zaman açık |
+| **TelemetryDeck** | Anonim, kategorik sinyaller: hangi sağlayıcıların kullanıldığı (değer değil, yalnızca var/yok) ve kaç widget eklendiği | Popover menüsünden kapatılabilir |
+
+İkisine de kota yüzdesi, sıfırlanma zamanı, kredi bakiyesi, hesap kimliği veya token gönderilmez. Geliştirme sürümleri hiçbir şey göndermez.
 
 ### Token yönetimi
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,32 +17,33 @@
 > Track your AI tool usage limits from the macOS menu bar.
 
 Mimir is a lightweight macOS menu bar app that shows real-time usage limits and
-reset countdowns for your AI tools — Claude, Codex, Gemini, and Antigravity —
-without leaving your workflow.
+reset countdowns for your AI tools — Claude, Codex and Antigravity (which covers
+Gemini, Claude and GPT) — without leaving your workflow.
 
 ### Features
 
 - **Menu bar at a glance** — all your AI service statuses in a single popover
-- **Live limits** — Claude session limits, Codex credits, and Gemini quotas, updated in real time
+- **Live limits** — session and weekly quotas, per-model rows and credit balances, updated in real time
+- **Desktop widgets** — Small and Medium widgets that track the popover
 - **Reset countdowns** — know exactly when each limit refreshes
 - **Color status dots** — green / amber / red based on remaining quota
 - **Minimalist design** — monochrome icon, full macOS light/dark mode support
-- **Privacy-first** — reads only local app configs and the macOS Keychain; no data ever leaves your machine
+- **No backend** — Mimir talks only to each provider's own endpoint, with that provider's own token; your quota figures and tokens go nowhere else
 
 ### Supported services
 
 | Service | Data source |
 |---|---|
-| **Claude** | Claude Code OAuth (`~/.claude`) |
+| **Claude** | Claude desktop app session, or Claude Code OAuth (`~/.claude`) |
 | **Codex** | ChatGPT usage API + local JSONL fallback |
-| **Antigravity** | Local language server + Cockpit |
+| **Antigravity** | Local language server + Cockpit (Gemini and Claude/GPT groups) |
 
 ### Installation
 
 **Requirements:** macOS 14.0 (Sonoma) or later · Swift 6.0+ (to build from source)
 
-**Download:** Grab the latest `.dmg` from the [Releases](https://github.com/erayendes/mimir/releases)
-page, open it, and drag **Mimir.app** to your Applications folder.
+**Download:** Grab the latest `Mimir.zip` from the [Releases](https://github.com/erayendes/mimir/releases)
+page, unzip it, and drag **Mimir.app** to your Applications folder.
 
 **Build from source:**
 
@@ -56,9 +57,9 @@ Full guide → **[Installation](INSTALLATION.md)**
 
 ### Reading the menu bar
 
-Mimir's entire UI lives in the menu bar: a small **Mimir glyph** and a vertical **column of colored dots**, one per service with a 5-hour session window (Claude, Codex, Antigravity — Antigravity's dot reflects its most-constrained group). A dot appears only for services with an active reading, so the count matches the LLMs you actually use.
+Mimir's entire UI lives in the menu bar: a small **Mimir glyph** and a vertical **column of colored dots**, one per service (Claude, Codex, Antigravity — Antigravity's dot reflects its most-constrained group). Each dot follows that service's session window, falling back to its weekly quota when there is no session window — which is the case for Codex since OpenAI removed its 5-hour limit. A dot appears only for services with an active reading, so the count matches the LLMs you actually use.
 
-**Dot colors** — based on the remaining percentage in the 5-hour window:
+**Dot colors** — based on the remaining percentage in the window the dot is tracking:
 
 | Color | Remaining | Meaning |
 |:---:|---|---|
@@ -66,7 +67,7 @@ Mimir's entire UI lives in the menu bar: a small **Mimir glyph** and a vertical 
 | 🟡 Amber | 15–49% | Running low |
 | 🔴 Red | below 15% | Near the limit |
 
-**The popover** — click the glyph to open it. Each service is a card with its name and brand icon, the session (5-hour) quota shown prominently with percentage and countdown, a weekly summary row, per-model quota or credit rows, an (i) info icon, and a status note (e.g. *"token expired — open Claude Code"*). Reset times use short units — e.g. `2h 15m`.
+**The popover** — click the glyph to open it. Each service is a card with its name and brand icon, the session (5-hour) quota shown prominently with percentage and countdown, a weekly summary row, per-model quota or credit rows, an (i) info icon, and a status note (e.g. *"token expired — open Claude Code"*). When a service has no session window, the weekly reading is promoted into that spot instead. Reset times use short units — e.g. `2h 15m`.
 
 **Refreshing & stale state** — Mimir refreshes every minute and on each popover open; if a service hits a rate limit (HTTP 429) it backs off and shows the last-known data. When a live source disappears (e.g. the Antigravity IDE closes), the card is shown **dimmed** with the last snapshot instead of vanishing.
 
@@ -77,9 +78,15 @@ Mimir's entire UI lives in the menu bar: a small **Mimir glyph** and a vertical 
 
 ### Privacy & Security
 
-Mimir never sends any personal data or API keys to remote servers. All data is
-fetched locally by reading tool log files (`~/.codex`, `~/.claude`, etc.) and
-macOS Keychain entries created by the respective apps.
+Mimir has no backend. Tokens are read from the files and macOS Keychain entries your
+tools already created (`~/.codex`, `~/.claude`, the Claude desktop app's session), and
+used only against each provider's own usage endpoint — the same request the tool itself
+would make. Your quota figures and tokens are never sent anywhere else.
+
+Released builds do send crash reports (Sentry) and anonymous, categorical usage signals
+(TelemetryDeck, opt-out from the popover menu). Neither receives quota values or tokens.
+
+Full detail → **[Privacy & Security](PRIVACY.md)**
 
 ### Roadmap
 
@@ -107,33 +114,34 @@ issue first. See [Contributing](../.github/CONTRIBUTING.md) · [Support & FAQ](.
 
 > AI araçlarınızın kullanım limitlerini macOS menü çubuğundan takip edin.
 
-Mimir; Claude, Codex, Gemini ve Antigravity gibi AI araçlarınızın kullanım
-limitlerini ve yenilenme sürelerini iş akışınızı bölmeden macOS menü çubuğundan
+Mimir; Claude, Codex ve Antigravity (Gemini, Claude ve GPT gruplarını kapsar) gibi
+AI araçlarınızın kullanım limitlerini ve yenilenme sürelerini iş akışınızı bölmeden macOS menü çubuğundan
 anlık olarak gösteren hafif bir uygulamadır.
 
 ### Özellikler
 
 - **Menü çubuğunda tek bakış** — tüm AI servislerinizin durumu tek bir popover'da
-- **Anlık limitler** — Claude seans limitleri, Codex kredileri ve Gemini kotaları gerçek zamanlı güncellenir
+- **Anlık limitler** — seans ve haftalık kotalar, model bazlı satırlar ve kredi bakiyeleri gerçek zamanlı güncellenir
+- **Masaüstü widget'ları** — popover'ı takip eden Small ve Medium boyutlar
 - **Geri sayım** — her limitin tam olarak ne zaman yenileneceğini gösterir
 - **Renkli durum noktaları** — kalan kotaya göre yeşil / amber / kırmızı
 - **Minimalist tasarım** — monokrom ikon, macOS açık/koyu tema desteği
-- **Gizlilik odaklı** — yalnızca yerel uygulama ayarlarını ve macOS Keychain'i okur; hiçbir veri makinenizden çıkmaz
+- **Arka uç yok** — Mimir yalnızca her sağlayıcının kendi uç noktasına, o sağlayıcının kendi token'ıyla bağlanır; kota bilgileriniz ve token'larınız başka hiçbir yere gitmez
 
 ### Desteklenen servisler
 
 | Servis | Veri kaynağı |
 |---|---|
-| **Claude** | Claude Code OAuth (`~/.claude`) |
+| **Claude** | Claude masaüstü uygulaması oturumu veya Claude Code OAuth (`~/.claude`) |
 | **Codex** | ChatGPT kullanım API'si + yerel JSONL yedeği |
-| **Antigravity** | Yerel dil sunucusu + Cockpit |
+| **Antigravity** | Yerel dil sunucusu + Cockpit (Gemini ve Claude/GPT grupları) |
 
 ### Kurulum
 
 **Gereksinimler:** macOS 14.0 (Sonoma) veya üzeri · Swift 6.0+ (kaynaktan derleme için)
 
 **İndirme:** [Releases](https://github.com/erayendes/mimir/releases) sayfasından son
-`.dmg` dosyasını indirin, açın ve **Mimir.app**'i Uygulamalar klasörünüze sürükleyin.
+`Mimir.zip` dosyasını indirin, arşivi açın ve **Mimir.app**'i Uygulamalar klasörünüze sürükleyin.
 
 **Kaynaktan derleme:**
 
@@ -147,9 +155,9 @@ Ayrıntılı rehber → **[Kurulum](INSTALLATION.md)**
 
 ### Menü çubuğunu okuma
 
-Mimir'in tüm arayüzü menü çubuğunda yaşar: küçük bir **Mimir simgesi** ve yanında dikey bir **renkli nokta sütunu** — 5 saatlik seans penceresine sahip her servis için bir nokta (Claude, Codex, Antigravity — Antigravity noktası en kısıtlı grubunu yansıtır). Nokta yalnızca aktif okuması olan servisler için görünür; yani nokta sayısı kullandığınız LLM sayısına eşittir.
+Mimir'in tüm arayüzü menü çubuğunda yaşar: küçük bir **Mimir simgesi** ve yanında dikey bir **renkli nokta sütunu** — her servis için bir nokta (Claude, Codex, Antigravity — Antigravity noktası en kısıtlı grubunu yansıtır). Her nokta o servisin seans penceresini izler; seans penceresi yoksa haftalık kotaya düşer — OpenAI 5 saatlik limiti kaldırdığından beri Codex'te durum budur. Nokta yalnızca aktif okuması olan servisler için görünür; yani nokta sayısı kullandığınız LLM sayısına eşittir.
 
-**Nokta renkleri** — 5 saatlik penceredeki kalan yüzdeye göre:
+**Nokta renkleri** — noktanın izlediği penceredeki kalan yüzdeye göre:
 
 | Renk | Kalan | Anlamı |
 |:---:|---|---|
@@ -157,7 +165,7 @@ Mimir'in tüm arayüzü menü çubuğunda yaşar: küçük bir **Mimir simgesi**
 | 🟡 Amber | %15–49 | Azalıyor |
 | 🔴 Kırmızı | %15'in altı | Limite yakın |
 
-**Açılır pencere (popover)** — simgeye tıklayınca açılır. Her servis bir karttır: ad ve marka ikonu, belirgin gösterilen seans (5 saatlik) kotası (yüzde + geri sayım), haftalık özet satırı, per-model kota veya kredi satırları, (i) bilgi simgesi ve bir durum notu (örn. *"token süresi doldu — Claude Code'u aç"*). Yenilenme süreleri kısa birimlerle: örn. `2s 15d`.
+**Açılır pencere (popover)** — simgeye tıklayınca açılır. Her servis bir karttır: ad ve marka ikonu, belirgin gösterilen seans (5 saatlik) kotası (yüzde + geri sayım), haftalık özet satırı, per-model kota veya kredi satırları, (i) bilgi simgesi ve bir durum notu (örn. *"token süresi doldu — Claude Code'u aç"*). Bir servisin seans penceresi yoksa haftalık okuma o alana terfi eder. Yenilenme süreleri kısa birimlerle: örn. `2s 15d`.
 
 **Yenileme & eski veri** — Mimir dakikada bir ve her popover açılışında yeniler; bir servis hız sınırına (HTTP 429) takılırsa geri çekilir ve son bilinen veriyi gösterir. Canlı kaynak kaybolduğunda (ör. Antigravity IDE'si kapanınca) kart yok olmaz, **soluk** (dimmed) hâlde son anlık görüntüyle kalır.
 
@@ -168,9 +176,17 @@ Mimir'in tüm arayüzü menü çubuğunda yaşar: küçük bir **Mimir simgesi**
 
 ### Gizlilik ve Güvenlik
 
-Mimir, kişisel verilerinizi veya API anahtarlarınızı hiçbir zaman uzak sunuculara
-göndermez. Tüm veriler yerel olarak araç log dosyaları (`~/.codex`, `~/.claude` vb.)
-ve ilgili uygulamaların oluşturduğu macOS Keychain kayıtları okunarak elde edilir.
+Mimir'in arka ucu yoktur. Token'lar, araçlarınızın zaten oluşturduğu dosyalardan ve macOS
+Keychain kayıtlarından okunur (`~/.codex`, `~/.claude`, Claude masaüstü uygulamasının
+oturumu) ve yalnızca ilgili sağlayıcının kendi kullanım uç noktasına karşı kullanılır —
+aracın kendisinin yapacağı isteğin aynısı. Kota bilgileriniz ve token'larınız başka
+hiçbir yere gönderilmez.
+
+Yayınlanan sürümler çökme raporu (Sentry) ve anonim, kategorik kullanım sinyali
+(TelemetryDeck, popover menüsünden kapatılabilir) gönderir. İkisi de kota değeri veya
+token almaz.
+
+Ayrıntı → **[Gizlilik ve Güvenlik](PRIVACY.md)**
 
 ### Yol Haritası
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -14,9 +14,12 @@ Jump to: [Claude](#claude) · [Codex](#codex) · [Antigravity](#antigravity)
 
 <img src="assets/claude.svg" alt="Claude" width="40" align="right">
 
-Mimir shows **Claude Code**'s usage limits: the session (5-hour) and weekly windows, with reset times.
+Mimir shows your Claude account's usage limits: the session (5-hour) and weekly windows, with reset times.
 
-**Data source.** Mimir uses the **OAuth token** that Claude Code creates on your machine to query Anthropic's official usage endpoint:
+**Data source.** Two paths, tried in order:
+
+1. **The Claude desktop app's session** (preferred). Mimir decrypts the app's own session cookie using the macOS Keychain key the app itself uses, then reads your account's live usage from claude.ai. This is what most people are actually on, and it stays accurate whether or not you use the CLI.
+2. **Claude Code's OAuth token**, used against Anthropic's official usage endpoint:
 
 ```
 GET https://api.anthropic.com/api/oauth/usage
@@ -47,7 +50,9 @@ Mimir shows session and weekly quotas for **Codex**, trying two sources in order
 2. **Local `~/.codex/sessions` JSONL fallback** — if the API is unreachable.
 3. If both fail, the **last-known snapshot**.
 
-**How the local fallback is read.** The **most recent `.jsonl` file** under `~/.codex/sessions` is scanned from the end backwards. From the `rate_limits` field of `token_count` events, Mimir extracts **primary** → session (5-hour) window and **secondary** → weekly window, then computes remaining percentages and reset times.
+**How the local fallback is read.** The **most recent `.jsonl` file** under `~/.codex/sessions` is scanned from the end backwards, taking the `rate_limits` field of `token_count` events.
+
+**How windows are classified.** Each window is identified by its **real length**, not by which slot it arrives in. OpenAI removed Codex's 5-hour limit in July 2026, so the single window it now returns is the *weekly* one — sitting in the `primary` slot, which used to mean "5-hour". A window of 6 hours or less is the session; anything longer is weekly. If the length is missing, Mimir falls back to how far the reset is (a 5-hour window can never reset more than 5h out), and only then to the slot. When there is no session window, the card drops that block and promotes the weekly reading rather than showing a misleading 100%.
 
 > 📝 **Note:** If no reset time is found in the local file, the card still shows the remaining percentage, but the countdown may be omitted (the card notes this).
 
@@ -93,9 +98,12 @@ Atla: [Claude](#claude-1) · [Codex](#codex-1) · [Antigravity](#antigravity-1)
 
 <img src="assets/claude.svg" alt="Claude" width="40" align="right">
 
-Mimir, **Claude Code**'un kullanım limitlerini gösterir: seans (5 saatlik) ve haftalık pencereler ile yenilenme zamanları.
+Mimir, Claude hesabınızın kullanım limitlerini gösterir: seans (5 saatlik) ve haftalık pencereler ile yenilenme zamanları.
 
-**Veri kaynağı.** Mimir, Claude Code'un makinenizde oluşturduğu **OAuth token'ını** kullanarak Anthropic'in resmî kullanım uç noktasını sorgular:
+**Veri kaynağı.** Sırayla denenen iki yol var:
+
+1. **Claude masaüstü uygulamasının oturumu** (tercih edilen). Mimir, uygulamanın kendi oturum çerezini, uygulamanın da kullandığı macOS Keychain anahtarıyla çözer ve hesabınızın canlı kullanımını claude.ai'den okur. Çoğu kullanıcının gerçekte bulunduğu yer burasıdır; CLI kullanıp kullanmadığınızdan bağımsız olarak doğru kalır.
+2. **Claude Code'un OAuth token'ı** ile Anthropic'in resmî kullanım uç noktası:
 
 ```
 GET https://api.anthropic.com/api/oauth/usage
@@ -126,7 +134,9 @@ Mimir, **Codex** için seans ve haftalık kotaları gösterir. İki kaynağı s�
 2. **Yerel `~/.codex/sessions` JSONL yedeği** — API erişilemezse.
 3. Her ikisi de başarısız olursa **son bilinen anlık görüntü** (snapshot).
 
-**Yerel yedek nasıl okunur?** `~/.codex/sessions` altındaki **en güncel `.jsonl` dosyası** sondan başa taranır. Mimir, `token_count` olaylarındaki `rate_limits` alanından **primary** → seans (5 saatlik) ve **secondary** → haftalık değerlerini çıkarır; kalan yüzdeleri ve sıfırlanma zamanlarını hesaplar.
+**Yerel yedek nasıl okunur?** `~/.codex/sessions` altındaki **en güncel `.jsonl` dosyası** sondan başa taranır; `token_count` olaylarındaki `rate_limits` alanı okunur.
+
+**Pencereler nasıl sınıflandırılır?** Her pencere, geldiği slota göre değil **gerçek uzunluğuna** göre tanınır. OpenAI Temmuz 2026'da Codex'in 5 saatlik limitini kaldırdı; bu yüzden artık dönen tek pencere *haftalık* olan — üstelik eskiden "5 saatlik" anlamına gelen `primary` slotunda. 6 saat ve altı seans, daha uzunu haftalık sayılır. Uzunluk bilgisi yoksa Mimir sıfırlanmanın ne kadar uzakta olduğuna bakar (5 saatlik bir pencere asla 5 saatten uzağa sıfırlanamaz), en son çare olarak slota. Seans penceresi yoksa kart o bloğu düşürür ve yanıltıcı bir %100 göstermek yerine haftalık okumayı öne çıkarır.
 
 > 📝 **Not:** Yerel dosyada sıfırlanma zamanı bulunamazsa kart yine kalan yüzdeyi gösterir, ancak geri sayım gösterilmeyebilir (kart bunu bir notla belirtir).
 


### PR DESCRIPTION
An accuracy pass over the docs, checked against the code rather than reread for style. Four of these were wrong, not merely dated.

## The download doesn't exist

README and INSTALLATION told people, in both languages, to grab the latest `.dmg`. Releases ship **`Mimir.zip`** — no `.dmg` is produced by any script or workflow. Eight occurrences, all repointed (and "open it" became "unzip it").

## The privacy claims were false

- README: *"no data ever leaves your machine"*
- SECURITY.md: *"This app runs entirely locally and sends no data over the network"*

Released builds report crashes to **Sentry** and send anonymous categorical signals to **TelemetryDeck**, and every quota read contacts a provider endpoint. PRIVACY.md documented Sentry but never mentioned TelemetryDeck — while stating data is *"relayed to no third party"*.

Replaced the blanket claim with what's true, and stronger for being verifiable: no backend, tokens and quota figures go nowhere else, plus a table of what each service actually receives (`Telemetry.swift` sends only booleans for which providers are active and a widget count — no percentages, reset times, credit balances, account ids or tokens; dev builds send nothing).

The one qualified claim in PRIVACY.md — *"…leaves your machine to reach **Mimir's** servers — because Mimir has no such servers"* — is accurate and was left alone.

## Stale behaviour

- **Claude's data source.** The desktop app's session has been the primary path since 2.6 (`ClaudeDesktopSession.swift`); the docs described the Claude Code OAuth path as the only one.
- **Codex window classification.** SERVICES.md still documented the pre-2.7 slot mapping (`primary` → 5-hour, `secondary` → weekly) — the exact assumption that produced the "5h, resets in 6d" bug. Now describes classification by real length, the reset-distance fallback, and dropping the session block when there's no session window.
- **Menu-bar dots.** Described as one dot per service "with a 5-hour session window". Codex has had no 5-hour window since OpenAI removed it; the dot follows the weekly quota.

## Gaps

- **Widgets** were not mentioned anywhere despite shipping and being fixed in 2.7.
- **Gemini** read as a fourth service alongside Claude/Codex/Antigravity; it's a group *inside* Antigravity, next to Claude/GPT. Now matches the repo description.

## Test

`.dmg` no longer appears anywhere under `docs/` or `.github/`; no unqualified "leaves your machine" / "sends no data" claims remain; TelemetryDeck is documented in both PRIVACY.md and README. Every relative link in `docs/`, `.github/` and `CLAUDE.md` was re-checked against its target — none broken. Both language halves updated in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)