### PR TITLE
fix(codex): label quota windows by their real length, not "weekly"

### DIFF
--- a/Sources/Mimir/CodexProvider.swift
+++ b/Sources/Mimir/CodexProvider.swift
@@ -29,6 +29,7 @@ extension LiveUsageDataSource {
         var weeklyRemaining: Int?
         var sessionReset: Date?
         var weeklyReset: Date?
+        var weeklyWindow: TimeInterval?
 
         for line in lines {
             guard let data = line.data(using: .utf8),
@@ -44,7 +45,8 @@ extension LiveUsageDataSource {
             let now = Date()
             for (w, slotIsPrimary) in [(rl.primary, true), (rl.secondary, false)] {
                 guard let w, let summary = summarizeCodexWindow(w, now: now) else { continue }
-                let isSession = codexWindowIsSession(periodSeconds: w.window_minutes.map { Double($0) * 60 },
+                let periodSeconds = w.window_minutes.map { Double($0) * 60 }
+                let isSession = codexWindowIsSession(periodSeconds: periodSeconds,
                                                      resetAt: summary.resetAt,
                                                      slotIsPrimary: slotIsPrimary, now: now)
                 if isSession, sessionRemaining == nil {
@@ -53,6 +55,8 @@ extension LiveUsageDataSource {
                 } else if weeklyRemaining == nil {
                     weeklyRemaining = remainingPercent(fromUsed: summary.usedPercent)
                     weeklyReset = summary.resetAt
+                    // Keep the real length so the UI can label a 30-day (Go plan) window correctly.
+                    weeklyWindow = periodSeconds
                 }
             }
 
@@ -76,6 +80,7 @@ extension LiveUsageDataSource {
             weeklyResetAt: weeklyReset,
             sessionRemainingPercent: sessionRemaining,
             weeklyRemainingPercent: weeklyRemaining,
+            weeklyWindowSeconds: weeklyWindow,
             models: [],
             isAvailable: true,
             statusNote: statusNote
@@ -133,11 +138,13 @@ extension LiveUsageDataSource {
 
         var session: (percent: Int, resetAt: Date?)?
         var weekly: (percent: Int, resetAt: Date?)?
+        var weeklyWindow: TimeInterval?
         for (raw, slotIsPrimary) in [(rateLimit["primary_window"], true), (rateLimit["secondary_window"], false)] {
             guard let obj = raw as? [String: Any] else { continue }
             let window = codexAPIWindow(obj)
             let percent = window.usedPercent.map(remainingPercent(fromUsed:)) ?? 100
-            let isSession = codexWindowIsSession(periodSeconds: doubleValue(obj["limit_window_seconds"]),
+            let periodSeconds = doubleValue(obj["limit_window_seconds"])
+            let isSession = codexWindowIsSession(periodSeconds: periodSeconds,
                                                  resetAt: window.resetAt,
                                                  slotIsPrimary: slotIsPrimary, now: now)
             // A second window that also reads as the session lands in the weekly slot rather than
@@ -146,6 +153,8 @@ extension LiveUsageDataSource {
                 session = (percent, window.resetAt)
             } else if weekly == nil {
                 weekly = (percent, window.resetAt)
+                // Keep the real length so the UI can label a 30-day (Go plan) window correctly.
+                weeklyWindow = periodSeconds
             }
         }
 
@@ -156,6 +165,7 @@ extension LiveUsageDataSource {
             weeklyResetAt: weekly?.resetAt,
             sessionRemainingPercent: session?.percent,
             weeklyRemainingPercent: weekly?.percent,
+            weeklyWindowSeconds: weeklyWindow,
             models: codexCreditRow(root["credits"]).map { [$0] } ?? [],
             isAvailable: true,
             statusNote: "chatgpt usage api"

--- a/Sources/Mimir/MimirModels.swift
+++ b/Sources/Mimir/MimirModels.swift
@@ -8,6 +8,10 @@ struct ServiceStatus: Identifiable {
     let weeklyResetAt: Date?
     let sessionRemainingPercent: Int?
     let weeklyRemainingPercent: Int?
+    /// Real length of the non-session window above, when the provider reports one (Codex does).
+    /// The UI labels that window from this rather than assuming 7 days — OpenAI's Go plan uses a
+    /// ~30-day window. nil = unknown, and the UI then falls back to its plain weekly label.
+    let weeklyWindowSeconds: TimeInterval?
     let models: [ModelStatus]
     let isAvailable: Bool
     let statusNote: String?
@@ -35,6 +39,7 @@ struct ServiceStatus: Identifiable {
         weeklyResetAt: Date?,
         sessionRemainingPercent: Int? = nil,
         weeklyRemainingPercent: Int? = nil,
+        weeklyWindowSeconds: TimeInterval? = nil,
         models: [ModelStatus],
         isAvailable: Bool,
         statusNote: String?,
@@ -49,6 +54,7 @@ struct ServiceStatus: Identifiable {
         self.weeklyResetAt = weeklyResetAt
         self.sessionRemainingPercent = sessionRemainingPercent
         self.weeklyRemainingPercent = weeklyRemainingPercent
+        self.weeklyWindowSeconds = weeklyWindowSeconds
         self.models = models
         self.isAvailable = isAvailable
         self.statusNote = statusNote
@@ -89,6 +95,7 @@ struct ServiceStatus: Identifiable {
             weeklyResetAt: weeklyResetAt,
             sessionRemainingPercent: sessionRemainingPercent,
             weeklyRemainingPercent: weeklyRemainingPercent,
+            weeklyWindowSeconds: weeklyWindowSeconds,
             models: models,
             isAvailable: isAvailable,
             statusNote: statusNote ?? self.statusNote,
@@ -131,6 +138,9 @@ struct SessionWindow: Equatable {
     let sessionResetAt: Date?
     let weeklyPercent: Int?
     let weeklyResetAt: Date?
+    /// Real length of the weekly window, when known — carried to the widget so it can label a
+    /// 30-day window as such instead of "7d". nil for per-model windows and unknown providers.
+    var weeklyWindowSeconds: TimeInterval? = nil
 }
 
 extension ServiceStatus {
@@ -147,7 +157,8 @@ extension ServiceStatus {
         // nil (a service visible only on its weekly reading): kept as one window so the menu bar still
         // shows a placeholder dot, while the widget drops it (no 5h number to render).
         return [SessionWindow(label: name, sessionPercent: sessionRemainingPercent, sessionResetAt: sessionResetAt,
-                              weeklyPercent: weeklyRemainingPercent, weeklyResetAt: weeklyResetAt)]
+                              weeklyPercent: weeklyRemainingPercent, weeklyResetAt: weeklyResetAt,
+                              weeklyWindowSeconds: weeklyWindowSeconds)]
     }
 }
 

--- a/Sources/Mimir/PopoverViews.swift
+++ b/Sources/Mimir/PopoverViews.swift
@@ -302,7 +302,8 @@ struct ServiceCard: View {
                                        gated: family.weekly?.percent == 0)
                         }
                         if let weekly = family.weekly {
-                            weeklyRow((label: family.name, percent: weekly.percent, resetAt: weekly.resetAt))
+                            weeklyRow((label: family.name, percent: weekly.percent, resetAt: weekly.resetAt,
+                                       windowSeconds: nil))
                                 .padding(.top, family.session != nil ? 8 : 0)
                         }
                     }
@@ -328,7 +329,13 @@ struct ServiceCard: View {
         .opacity(service.isStale ? 0.66 : 1)
     }
 
-    private func weeklyRow(_ entry: (label: String, percent: Int, resetAt: Date?)) -> some View {
+    /// Badge text for a quota window, built from its REAL length ("7g", "30g"). nil when the provider
+    /// doesn't report one, so the caller keeps its plain weekly label rather than printing a guess.
+    private func windowBadge(_ seconds: TimeInterval?) -> String? {
+        quotaWindowDays(seconds).map { "\($0)\(TimeFormatter.dayUnit)" }
+    }
+
+    private func weeklyRow(_ entry: (label: String, percent: Int, resetAt: Date?, windowSeconds: TimeInterval?)) -> some View {
         // The 7g dot uses the weekly bands (amber ≥10%, red below) — at 0% it stays red here; it's the
         // 5s session that greys out to flag the lockout (see SessionRow `gated`).
         HStack(spacing: 8) {
@@ -339,7 +346,7 @@ struct ServiceCard: View {
                 .font(.system(size: 11, weight: .regular))
                 .foregroundStyle(Color.primary.opacity(0.62))
                 .lineLimit(1)
-            QuotaBadge(text: String(localized: "7g"))
+            QuotaBadge(text: windowBadge(entry.windowSeconds) ?? String(localized: "7g"))
             Spacer(minLength: 6)
             Text("%\(clampPct(entry.percent))")
                 .font(.system(size: 11, weight: .semibold).monospacedDigit())
@@ -355,22 +362,23 @@ struct ServiceCard: View {
 
     /// Weekly rows. Claude/Codex: the all-models weekly (labelled with the service name)
     /// plus any per-model weekly (e.g. Sonnet). Antigravity: its grouped weekly buckets.
-    private var weeklyEntries: [(label: String, percent: Int, resetAt: Date?)] {
+    private var weeklyEntries: [(label: String, percent: Int, resetAt: Date?, windowSeconds: TimeInterval?)] {
         if hasServiceQuotas {
-            var out: [(label: String, percent: Int, resetAt: Date?)] = []
+            var out: [(label: String, percent: Int, resetAt: Date?, windowSeconds: TimeInterval?)] = []
             // The account weekly is a row only when there IS a 5h session above it; with no session the
             // weekly is promoted into the hero block (see sessionHeroes), so don't repeat it here.
             if service.sessionRemainingPercent != nil, let weekly = service.weeklyRemainingPercent {
-                out.append((service.name, weekly, service.weeklyResetAt))
+                out.append((service.name, weekly, service.weeklyResetAt, service.weeklyWindowSeconds))
             }
+            // Per-model weeklies carry no length of their own — they keep the plain weekly badge.
             for model in service.models where model.valueText == nil {
-                out.append((model.name, model.remainingPercent, model.resetAt))
+                out.append((model.name, model.remainingPercent, model.resetAt, nil))
             }
             return out
         }
         return service.models
             .filter { $0.window == .weekly && $0.valueText == nil }
-            .map { (label: $0.name, percent: $0.remainingPercent, resetAt: $0.resetAt) }
+            .map { (label: $0.name, percent: $0.remainingPercent, resetAt: $0.resetAt, windowSeconds: nil) }
     }
 
     /// The prominent block (Claude/Codex — one each). Normally the 5-hour session; but when a service
@@ -383,7 +391,8 @@ struct ServiceCard: View {
         }
         if let weekly = service.weeklyRemainingPercent {
             return [(service.name, weekly, service.weeklyResetAt,
-                     String(localized: "7g"), 7 * 24 * 3600, false)]
+                     windowBadge(service.weeklyWindowSeconds) ?? String(localized: "7g"),
+                     service.weeklyWindowSeconds ?? 7 * 24 * 3600, false)]
         }
         return []
     }

--- a/Sources/Mimir/WidgetBridge.swift
+++ b/Sources/Mimir/WidgetBridge.swift
@@ -95,7 +95,7 @@ enum WidgetBridge {
             if let weeklyPct = w.weeklyPercent {
                 return WindowMetric(label: w.label, percent: weeklyPct, resetAt: w.weeklyResetAt,
                                     weeklyPercent: w.weeklyPercent, weeklyResetAt: w.weeklyResetAt,
-                                    isWeekly: true)
+                                    isWeekly: true, windowSeconds: w.weeklyWindowSeconds)
             }
             return nil
         }

--- a/Sources/MimirShared/WidgetPayload.swift
+++ b/Sources/MimirShared/WidgetPayload.swift
@@ -56,6 +56,19 @@ public struct ProviderPayload: Codable, Equatable {
     }
 }
 
+/// Whole days in a non-session quota window, for labelling it by its REAL length instead of
+/// assuming "longer than a session means exactly 7 days". OpenAI's ChatGPT Go plan moved to a
+/// ~30-day window in mid-2026, which a hardcoded "7d" badge would misreport.
+///
+/// Derived from the window's total length, never from how far the reset is — on day 27 of a
+/// 30-day window the remaining time is 3 days, but the window is still a 30-day one.
+/// Returns nil for session-length (<= 6h) or unknown windows, so callers can omit the badge
+/// rather than print a wrong number.
+public func quotaWindowDays(_ windowSeconds: TimeInterval?) -> Int? {
+    guard let windowSeconds, windowSeconds > 6 * 3600 else { return nil }
+    return max(1, Int((windowSeconds / 86_400).rounded()))
+}
+
 public struct WindowMetric: Codable, Equatable {
     public var label: String         // row label: "Claude" / "Gemini" / "Claude/GPT" / "Sonnet" …
     public var percent: Int          // remaining %, drives bar width + status colour
@@ -68,23 +81,28 @@ public struct WindowMetric: Codable, Equatable {
     // i.e. this service has no active 5h window (Codex since OpenAI's July 2026 removal), so the widget
     // shows its weekly reading as the headline and labels the pill "7g" instead of "5s".
     public var isWeekly: Bool
+    // Real length of the window `percent`/`resetAt` describe, when the provider reports one. Lets the
+    // widget label it by its actual size (7d vs 30d) instead of assuming weekly. nil = unknown.
+    public var windowSeconds: TimeInterval?
 
     public init(label: String, percent: Int, resetAt: Date?,
-                weeklyPercent: Int? = nil, weeklyResetAt: Date? = nil, isWeekly: Bool = false) {
+                weeklyPercent: Int? = nil, weeklyResetAt: Date? = nil, isWeekly: Bool = false,
+                windowSeconds: TimeInterval? = nil) {
         self.label = label
         self.percent = percent
         self.resetAt = resetAt
         self.weeklyPercent = weeklyPercent
         self.weeklyResetAt = weeklyResetAt
         self.isWeekly = isWeekly
+        self.windowSeconds = windowSeconds
     }
 
     private enum CodingKeys: String, CodingKey {
-        case label, percent, resetAt, weeklyPercent, weeklyResetAt, isWeekly
+        case label, percent, resetAt, weeklyPercent, weeklyResetAt, isWeekly, windowSeconds
     }
 
-    // Custom decode so a payload written by an older app version (no `isWeekly` key) still reads —
-    // otherwise the widget would fail to decode and blank out during the post-update window.
+    // Custom decode so a payload written by an older app version (no `isWeekly`/`windowSeconds` key)
+    // still reads — otherwise the widget would fail to decode and blank out post-update.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         label = try c.decode(String.self, forKey: .label)
@@ -93,6 +111,7 @@ public struct WindowMetric: Codable, Equatable {
         weeklyPercent = try c.decodeIfPresent(Int.self, forKey: .weeklyPercent)
         weeklyResetAt = try c.decodeIfPresent(Date.self, forKey: .weeklyResetAt)
         isWeekly = try c.decodeIfPresent(Bool.self, forKey: .isWeekly) ?? false
+        windowSeconds = try c.decodeIfPresent(TimeInterval.self, forKey: .windowSeconds)
     }
 }
 

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import MimirShared
 @testable import Mimir
 
 /// Covers the pure parsing/math helpers in LiveUsageDataSource — the fragile, reverse-engineered
@@ -67,6 +68,49 @@ final class UsageParsingTests: XCTestCase {
         XCTAssertEqual(status.weeklyRemainingPercent, 99)                  // classified as weekly
         XCTAssertEqual(status.weeklyResetAt, Date(timeIntervalSince1970: 1_785_822_607))
         XCTAssertTrue(status.models.isEmpty)                              // no credits row
+    }
+
+    /// ChatGPT Go moved its quota to a ~30-day window in mid-2026. It must be kept as the window's
+    /// REAL length so the UI can label it "30d" — the old code bucketed anything over 6h as "7d".
+    func testCodexStatusKeepsMonthlyWindowLength() {
+        let root: [String: Any] = [
+            "rate_limit": [
+                "primary_window": ["used_percent": 10.0, "limit_window_seconds": 2_592_000, "reset_at": 1_785_822_607.0],
+            ],
+        ]
+        let status = ds.codexStatus(fromUsageRoot: root)
+        XCTAssertNil(status.sessionRemainingPercent)
+        XCTAssertEqual(status.weeklyRemainingPercent, 90)
+        XCTAssertEqual(status.weeklyWindowSeconds, 2_592_000)
+        XCTAssertEqual(quotaWindowDays(status.weeklyWindowSeconds), 30)
+    }
+
+    /// The weekly window's length reaches the UI for the ordinary 7-day case too.
+    func testCodexStatusKeepsWeeklyWindowLength() {
+        let root: [String: Any] = [
+            "rate_limit": [
+                "primary_window": ["used_percent": 1.0, "limit_window_seconds": 604800, "reset_at": 1_785_822_607.0],
+            ],
+        ]
+        XCTAssertEqual(quotaWindowDays(ds.codexStatus(fromUsageRoot: root).weeklyWindowSeconds), 7)
+    }
+
+    /// No length reported → nil, so the UI keeps its plain weekly badge instead of printing a guess.
+    func testCodexStatusWithoutWindowLengthLeavesItNil() {
+        let root: [String: Any] = [
+            "rate_limit": ["secondary_window": ["used_percent": 5.0, "reset_at": 1_785_822_607.0]],
+        ]
+        XCTAssertNil(ds.codexStatus(fromUsageRoot: root).weeklyWindowSeconds)
+    }
+
+    /// The badge must come from the window's total length, never from the countdown — on day 27 of a
+    /// 30-day window it still reads "30d". Session-length and unknown windows get no day badge.
+    func testQuotaWindowDaysUsesWindowLengthNotRemainingTime() {
+        XCTAssertEqual(quotaWindowDays(2_592_000), 30)      // 30d
+        XCTAssertEqual(quotaWindowDays(604800), 7)          // 7d
+        XCTAssertEqual(quotaWindowDays(3 * 86_400), 3)      // a 3-day window is "3d", not "7d"
+        XCTAssertNil(quotaWindowDays(18000))                // 5h session → no day badge
+        XCTAssertNil(quotaWindowDays(TimeInterval?.none))   // unknown → no badge
     }
 
     /// Both windows present with real durations: the 5-hour one (limit_window_seconds 18000) is the

--- a/Tests/MimirTests/WidgetBridgeTests.swift
+++ b/Tests/MimirTests/WidgetBridgeTests.swift
@@ -62,6 +62,34 @@ final class WidgetBridgeTests: XCTestCase {
         XCTAssertEqual(m.weeklyPercent, 72)
     }
 
+    /// The weekly window's real length reaches the widget, so a ~30-day Go-plan window renders a "30d"
+    /// pill instead of the hardcoded "7d" the widget used to print for anything longer than a session.
+    func testWeeklyWindowLengthReachesWidget() {
+        let codex = ServiceStatus(
+            name: "Codex", iconName: "codex",
+            sessionResetAt: nil, weeklyResetAt: now.addingTimeInterval(86_400),
+            sessionRemainingPercent: nil, weeklyRemainingPercent: 72,
+            weeklyWindowSeconds: 2_592_000,
+            models: [], isAvailable: true, statusNote: nil)
+
+        let m = WidgetBridge.makePayload([codex], generatedAt: now).providers.first!.fiveHour.first!
+        XCTAssertTrue(m.isWeekly)
+        XCTAssertEqual(m.windowSeconds, 2_592_000)
+        XCTAssertEqual(quotaWindowDays(m.windowSeconds), 30)
+    }
+
+    /// A payload written by an older app version has no `windowSeconds` key — it must still decode
+    /// (nil, so the widget keeps its plain weekly pill) rather than blanking the widget post-update.
+    func testOlderPayloadWithoutWindowSecondsStillDecodes() throws {
+        let json = Data("""
+        {"label":"Codex","percent":72,"isWeekly":true}
+        """.utf8)
+        let m = try JSONDecoder().decode(WindowMetric.self, from: json)
+        XCTAssertEqual(m.percent, 72)
+        XCTAssertTrue(m.isWeekly)
+        XCTAssertNil(m.windowSeconds)
+    }
+
     /// A service with neither a session nor a weekly reading produces no metric (dropped, not a zero row).
     func testNoWindowsProducesNoMetric() {
         let codex = ServiceStatus(

--- a/WidgetExtension/MimirWidget/DetailedWidget.swift
+++ b/WidgetExtension/MimirWidget/DetailedWidget.swift
@@ -8,14 +8,21 @@ private let fiveHourWindow: TimeInterval = 5 * 3600
 /// (a service with no active 5h window, e.g. Codex since OpenAI's July 2026 removal).
 private let weeklyWindow: TimeInterval = 7 * 24 * 3600
 
-/// The pill text for a metric's window: "7d/7g" when it's the weekly quota, else "5h/5s".
+/// The pill text for a metric's window: "5h/5s" for the session, else the window's REAL length
+/// ("7d", "30d" — OpenAI's Go plan uses a ~30-day window). Falls back to the plain weekly label
+/// when the provider reports no length, rather than printing a guessed day count.
 private func windowPill(_ m: WindowMetric) -> String {
-    m.isWeekly ? String(localized: "widget.window.weekly") : String(localized: "widget.window.fiveHour")
+    guard m.isWeekly else { return String(localized: "widget.window.fiveHour") }
+    if let days = quotaWindowDays(m.windowSeconds) {
+        return "\(days)\(String(localized: "duration.unit.day"))"
+    }
+    return String(localized: "widget.window.weekly")
 }
 
-/// The reset countdown fallback length matching a metric's window (weekly vs 5-hour).
+/// The reset countdown fallback length matching a metric's window (its real length when known).
 private func windowFallback(_ m: WindowMetric) -> TimeInterval {
-    m.isWeekly ? weeklyWindow : fiveHourWindow
+    guard m.isWeekly else { return fiveHourWindow }
+    return m.windowSeconds ?? weeklyWindow
 }
 
 // A 5-hour metric paired with its provider's logo, flattened across providers for the Small

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [2.8] - 2026-08-09
+
+#### Fixed
+- Codex quota windows are now labelled with their real length instead of always "7d". ChatGPT Go moved its Codex allowance to a roughly monthly window while Plus and Pro stayed weekly, so Go users were told their month-long quota resets in a week. The badge now reads "30d" when the window is a month, "7d" when it's a week — and it comes from the window's full length, not the countdown, so it still says "30d" on day 27.
+
+#### Internal
+- The quota window's reported length is carried through to the popover and the widget, so any future window size labels itself correctly without a code change. When a provider reports no length, the plain weekly label is kept rather than a guessed number.
+
 ### [2.7] - 2026-07-31
 
 #### Fixed
@@ -376,6 +384,14 @@ Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
 
 ### [Yayımlanmadı]
+
+### [2.8] - 2026-08-09
+
+#### Düzeltildi
+- Codex kota pencereleri artık hep "7g" değil, gerçek uzunluğuyla etiketleniyor. ChatGPT Go, Codex hakkını kabaca aylık bir pencereye taşıdı; Plus ve Pro haftalık kaldı. Bu yüzden Go kullanıcılarına aylık kotaları bir hafta içinde sıfırlanacakmış gibi görünüyordu. Rozet artık pencere bir aylıksa "30g", bir haftalıksa "7g" yazıyor — üstelik geri sayımdan değil pencerenin tam uzunluğundan geldiği için 27. günde bile "30g" diyor.
+
+#### İçeride
+- Kota penceresinin bildirilen uzunluğu popover'a ve widget'a kadar taşınıyor; böylece ileride çıkacak herhangi bir pencere boyutu kod değişikliği olmadan doğru etiketleniyor. Sağlayıcı uzunluk bildirmiyorsa tahmini bir sayı yerine düz haftalık etiketi korunuyor.
 
 ### [2.7] - 2026-07-31
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -52,7 +52,9 @@ Mimir shows session and weekly quotas for **Codex**, trying two sources in order
 
 **How the local fallback is read.** The **most recent `.jsonl` file** under `~/.codex/sessions` is scanned from the end backwards, taking the `rate_limits` field of `token_count` events.
 
-**How windows are classified.** Each window is identified by its **real length**, not by which slot it arrives in. OpenAI removed Codex's 5-hour limit in July 2026, so the single window it now returns is the *weekly* one — sitting in the `primary` slot, which used to mean "5-hour". A window of 6 hours or less is the session; anything longer is weekly. If the length is missing, Mimir falls back to how far the reset is (a 5-hour window can never reset more than 5h out), and only then to the slot. When there is no session window, the card drops that block and promotes the weekly reading rather than showing a misleading 100%.
+**How windows are classified.** Each window is identified by its **real length**, not by which slot it arrives in. OpenAI removed Codex's 5-hour limit in July 2026, so the single window it now returns is the *weekly* one — sitting in the `primary` slot, which used to mean "5-hour". A window of 6 hours or less is the session; anything longer is a longer-term quota. If the length is missing, Mimir falls back to how far the reset is (a 5-hour window can never reset more than 5h out), and only then to the slot. When there is no session window, the card drops that block and promotes the longer-term reading rather than showing a misleading 100%.
+
+**Longer-term windows are labelled by their real size, not assumed to be 7 days.** The badge ("7d", "30d") comes from the window's reported total length — ChatGPT Go moved to a ~30-day window in mid-2026, and Plus/Pro stayed weekly. The badge is derived from the window length only, never from the countdown: on day 27 of a 30-day window the badge still reads "30d". When a provider reports no length, Mimir shows its plain weekly label rather than printing a guessed number.
 
 > 📝 **Note:** If no reset time is found in the local file, the card still shows the remaining percentage, but the countdown may be omitted (the card notes this).
 
@@ -136,7 +138,9 @@ Mimir, **Codex** için seans ve haftalık kotaları gösterir. İki kaynağı s�
 
 **Yerel yedek nasıl okunur?** `~/.codex/sessions` altındaki **en güncel `.jsonl` dosyası** sondan başa taranır; `token_count` olaylarındaki `rate_limits` alanı okunur.
 
-**Pencereler nasıl sınıflandırılır?** Her pencere, geldiği slota göre değil **gerçek uzunluğuna** göre tanınır. OpenAI Temmuz 2026'da Codex'in 5 saatlik limitini kaldırdı; bu yüzden artık dönen tek pencere *haftalık* olan — üstelik eskiden "5 saatlik" anlamına gelen `primary` slotunda. 6 saat ve altı seans, daha uzunu haftalık sayılır. Uzunluk bilgisi yoksa Mimir sıfırlanmanın ne kadar uzakta olduğuna bakar (5 saatlik bir pencere asla 5 saatten uzağa sıfırlanamaz), en son çare olarak slota. Seans penceresi yoksa kart o bloğu düşürür ve yanıltıcı bir %100 göstermek yerine haftalık okumayı öne çıkarır.
+**Pencereler nasıl sınıflandırılır?** Her pencere, geldiği slota göre değil **gerçek uzunluğuna** göre tanınır. OpenAI Temmuz 2026'da Codex'in 5 saatlik limitini kaldırdı; bu yüzden artık dönen tek pencere *haftalık* olan — üstelik eskiden "5 saatlik" anlamına gelen `primary` slotunda. 6 saat ve altı seans, daha uzunu uzun vadeli kota sayılır. Uzunluk bilgisi yoksa Mimir sıfırlanmanın ne kadar uzakta olduğuna bakar (5 saatlik bir pencere asla 5 saatten uzağa sıfırlanamaz), en son çare olarak slota. Seans penceresi yoksa kart o bloğu düşürür ve yanıltıcı bir %100 göstermek yerine uzun vadeli okumayı öne çıkarır.
+
+**Uzun vadeli pencereler 7 gün varsayılmaz, gerçek boyutuyla etiketlenir.** Rozet ("7g", "30g") pencerenin bildirilen toplam uzunluğundan gelir — ChatGPT Go 2026 ortasında ~30 günlük pencereye geçti, Plus/Pro haftalık kaldı. Rozet yalnızca pencere uzunluğundan türetilir, geri sayımdan asla: 30 günlük bir pencerenin 27. gününde de rozet "30g" yazar. Sağlayıcı uzunluk bildirmiyorsa Mimir tahmini bir sayı yazmak yerine düz haftalık etiketini gösterir.
 
 > 📝 **Not:** Yerel dosyada sıfırlanma zamanı bulunamazsa kart yine kalan yüzdeyi gösterir, ancak geri sayım gösterilmeyebilir (kart bunu bir notla belirtir).
 


### PR DESCRIPTION
## Problem

ChatGPT **Go** moved its Codex quota to a roughly **30-day** window in mid-2026; Plus and Pro stayed weekly. OpenAI never documented it — it surfaced through user reports of quotas silently switching from weekly to monthly resets.

Mimir classifies windows by duration (`<=6h` = session, longer = weekly), which was right as far as it went. But everything downstream assumed "longer than a session" meant **exactly 7 days**:

- `PopoverViews.sessionHeroes` — hardcoded `"7g"` badge and a `7 * 24 * 3600` reset fallback
- `weeklyRow` — hardcoded `"7g"` badge
- `DetailedWidget.windowPill` / `windowFallback` — `widget.window.weekly` and `weeklyWindow`

So a Go user's month-long quota was reported as resetting in a week. Same class of bug as the one fixed in 2.7, one layer up: that one was "primary slot means 5-hour", this one is "not a session means exactly a week".

## Fix

Carry the window's reported length (`limit_window_seconds` / `window_minutes`) through `ServiceStatus` → `SessionWindow` → `WindowMetric`, and derive the badge from it.

The badge comes from the window's **total length, never the countdown** — on day 27 of a 30-day window it still reads "30d". Deriving it from the remaining time would produce "3d" there, which is the trap this design avoids. When a provider reports no length, the plain weekly label is kept rather than printing a guessed day count.

Nothing keys off a plan name. The exact payload a Go account returns is **unverified** (no Go access here, and no one has published the fields), so this works purely off the length the API already sends — 30 days, 28 days or anything else labels itself correctly.

## Scope

- Claude and Antigravity report no window length → `nil` → unchanged behaviour
- Widget payloads written by older versions still decode (`windowSeconds` absent → `nil`), so the widget can't blank out during the update window
- Classification threshold (`<=6h` = session) untouched

## Verification

- `swift test` — 84 passed, 6 new
- `BUILD_ONLY=1 ./script/release.sh 0.0` — app + widget extension build
- `build_number.sh 2.8` → `2008000` (> 2.7's `2007000`)
- Release-note extraction tested with the workflow's own awk: both EN and TR sections resolve

## Sources

- [Usage quotas changed to monthly? — OpenAI Developer Community](https://community.openai.com/t/usage-quotas-changed-to-monthly/1382696)
- [Using Codex with your ChatGPT plan — OpenAI Help Center](https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)