### PR TITLE
feat: v2.9 — provider cards, ChatGPT reset credits, wake-safe polling

### DIFF
--- a/Sources/Mimir/AntigravityProvider.swift
+++ b/Sources/Mimir/AntigravityProvider.swift
@@ -181,10 +181,24 @@ extension LiveUsageDataSource {
             let one = credits.first { ($0["creditType"] as? String)?.contains("GOOGLE_ONE") == true } ?? credits[0]
             guard let amount = num(one["creditAmount"]) else { return nil }
             let minimum = num(one["minimumCreditAmountForUsage"]) ?? 0
-            return ModelStatus(name: String(localized: "Google One credits"), remainingPercent: 0, resetAt: nil,
-                               valueText: String(Int(amount)), isLow: amount < minimum)
+            return ModelStatus(name: antigravityCreditLabel(one["creditType"] as? String),
+                               remainingPercent: 0, resetAt: nil,
+                               valueText: String(Int(amount)), isLow: amount < minimum, symbol: "sparkles")
         }
         return nil
+    }
+
+    /// Label for the credit row. Google One is the only type seen in the wild, so it gets the
+    /// designed "AI credit" name; anything else is titled from the raw type (GEMINI_ULTRA →
+    /// "Gemini Ultra") rather than being mislabelled as Google One.
+    func antigravityCreditLabel(_ creditType: String?) -> String {
+        guard let creditType, !creditType.isEmpty, !creditType.contains("GOOGLE_ONE") else {
+            return String(localized: "AI credit")
+        }
+        return creditType
+            .split(whereSeparator: { $0 == "_" || $0 == "-" })
+            .map(\.capitalized)
+            .joined(separator: " ")
     }
 
     /// Flatten `groups[].buckets[]` into one row per (group × window), ordered 5h then

--- a/Sources/Mimir/ClaudeProvider.swift
+++ b/Sources/Mimir/ClaudeProvider.swift
@@ -245,8 +245,11 @@ extension LiveUsageDataSource {
         }
         let text = limit.map { "\(money(used)) / \(money($0))" } ?? money(used)
         let util = doubleValue(spend["percent"]) ?? (limit.map { $0 > 0 ? used / $0 * 100 : 0 } ?? 0)
-        return ModelStatus(name: String(localized: "Billing"), remainingPercent: 0, resetAt: nil,
-                           valueText: text, isLow: util >= 80)
+        // Prefer the API's own judgement when it ships one; otherwise the 80%-of-cap heuristic.
+        let low = (spend["severity"] as? String)
+            .map { !["none", "normal", "ok"].contains($0.lowercased()) } ?? (util >= 80)
+        return ModelStatus(name: String(localized: "Usage credit"), remainingPercent: 0, resetAt: nil,
+                           valueText: text, isLow: low, symbol: "dollarsign.circle")
     }
 
     private func claudeLegacyBillingRow(_ raw: Any?) -> ModelStatus? {
@@ -260,8 +263,8 @@ extension LiveUsageDataSource {
         }
         let text = limit.map { "\(money(used)) / \(money($0))" } ?? money(used)
         let util = doubleValue(e["utilization"]) ?? (limit.map { $0 > 0 ? used / $0 * 100 : 0 } ?? 0)
-        return ModelStatus(name: String(localized: "Billing"), remainingPercent: 0, resetAt: nil,
-                           valueText: text, isLow: util >= 80)
+        return ModelStatus(name: String(localized: "Usage credit"), remainingPercent: 0, resetAt: nil,
+                           valueText: text, isLow: util >= 80, symbol: "dollarsign.circle")
     }
     private func mergeClaudeWindows(root: [String: Any], baseKey: String) -> (utilization: Double, resetAt: Date?) {
         var bestUtil = 0.0

--- a/Sources/Mimir/CodexProvider.swift
+++ b/Sources/Mimir/CodexProvider.swift
@@ -120,7 +120,8 @@ extension LiveUsageDataSource {
                   root["rate_limit"] is [String: Any] else {
                 return nil
             }
-            return codexStatus(fromUsageRoot: root)
+            let resetRow = await fetchCodexResetCredits(accessToken: accessToken, accountID: accountID)
+            return codexStatus(fromUsageRoot: root, extraRows: resetRow.map { [$0] } ?? [])
         } catch {
             return nil
         }
@@ -133,7 +134,7 @@ extension LiveUsageDataSource {
     /// longer implies "5-hour". A window of <= 6h is the 5-hour session, anything longer is the weekly
     /// one; see `codexWindowIsSession` for what happens when the period field is missing. An absent
     /// window stays nil (no misleading "100%"). If the 5h window returns later, it's the session again.
-    func codexStatus(fromUsageRoot root: [String: Any], now: Date = Date()) -> ServiceStatus {
+    func codexStatus(fromUsageRoot root: [String: Any], now: Date = Date(), extraRows: [ModelStatus] = []) -> ServiceStatus {
         let rateLimit = root["rate_limit"] as? [String: Any] ?? [:]
 
         var session: (percent: Int, resetAt: Date?)?
@@ -166,7 +167,7 @@ extension LiveUsageDataSource {
             sessionRemainingPercent: session?.percent,
             weeklyRemainingPercent: weekly?.percent,
             weeklyWindowSeconds: weeklyWindow,
-            models: codexCreditRow(root["credits"]).map { [$0] } ?? [],
+            models: (codexCreditRow(root["credits"]).map { [$0] } ?? []) + extraRows,
             isAvailable: true,
             statusNote: "chatgpt usage api"
         )
@@ -176,15 +177,57 @@ extension LiveUsageDataSource {
     /// Returns nil for free/Plus accounts with no credits, so the row is simply omitted.
     private func codexCreditRow(_ raw: Any?) -> ModelStatus? {
         guard let c = raw as? [String: Any] else { return nil }
+        let label = String(localized: "Credit balance")
         if c["unlimited"] as? Bool == true {
-            return ModelStatus(name: String(localized: "Credits"), remainingPercent: 0, resetAt: nil, valueText: String(localized: "Unlimited"))
+            return ModelStatus(name: label, remainingPercent: 0, resetAt: nil,
+                               valueText: String(localized: "Unlimited"), symbol: "dollarsign.circle")
         }
         guard c["has_credits"] as? Bool == true else { return nil }
         let amount = (c["balance"] as? String).flatMap(Double.init) ?? doubleValue(c["balance"]) ?? 0
         guard amount > 0 else { return nil }
         let text = amount.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(amount)) : String(amount)
-        return ModelStatus(name: String(localized: "Credits"), remainingPercent: 0, resetAt: nil,
-                           valueText: String(format: String(localized: "%@ credits"), text), isLow: amount < 5)
+        return ModelStatus(name: label, remainingPercent: 0, resetAt: nil,
+                           valueText: String(format: String(localized: "%@ credits"), text), isLow: amount < 5,
+                           symbol: "dollarsign.circle")
+    }
+
+    /// Reset credits ("sıfırlama hakkı") from `wham/rate-limit-reset-credits`: one-shot passes that
+    /// clear a spent rate-limit window. Only credits still available AND not yet expired count — a
+    /// credit can lapse between polls, and `available_count` doesn't re-check that.
+    /// Returns nil when there are none, so the row is simply omitted.
+    func codexResetCreditRow(fromRoot root: [String: Any], now: Date = Date()) -> ModelStatus? {
+        let credits = (root["credits"] as? [[String: Any]] ?? []).compactMap { item -> Date? in
+            guard (item["status"] as? String)?.lowercased() == "available",
+                  let raw = item["expires_at"] as? String,
+                  let expiresAt = parseISO8601(raw), expiresAt > now else { return nil }
+            return expiresAt
+        }
+        guard !credits.isEmpty else { return nil }
+        let caption = credits.min().map {
+            String(format: String(localized: "first expires in %@"), TimeFormatter.duration(from: $0.timeIntervalSince(now)))
+        }
+        return ModelStatus(name: String(localized: "Reset credits"), remainingPercent: 0, resetAt: nil,
+                           valueText: String(credits.count), caption: caption, symbol: "arrow.clockwise")
+    }
+
+    /// GET the reset-credit endpoint with the same auth as `wham/usage`. Failure returns nil and the
+    /// row is dropped — this is a bonus reading, never a reason to fail the whole Codex fetch.
+    private func fetchCodexResetCredits(accessToken: String, accountID: String?) async -> ModelStatus? {
+        var req = URLRequest(url: URL(string: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")!,
+                             timeoutInterval: 10)
+        req.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("Mimir", forHTTPHeaderField: "User-Agent")
+        if let accountID, !accountID.isEmpty {
+            req.setValue(accountID, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+
+        guard let (data, response) = try? await URLSession.shared.data(for: req),
+              (response as? HTTPURLResponse).map({ 200 ... 299 ~= $0.statusCode }) == true,
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return codexResetCreditRow(fromRoot: root)
     }
     private func summarizeCodexWindow(_ window: CodexRateWindow?, now: Date) -> CodexWindowSummary? {
         guard let window else { return nil }

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -43,6 +43,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }()
     private var statusItem: NSStatusItem?
     private var timer: Timer?
+    /// Sleep/wake poll guard (see `WakeScheduling`): when the last poll ran, and when the
+    /// repeating timer was due to fire next — a fire far past that means the machine slept.
+    private var lastPoll: Date?
+    private var nextExpectedFire: Date?
+    private var wakeRefresh: DispatchWorkItem?
     private var localEventMonitor: Any?
     private var globalEventMonitor: Any?
     private var resignObserver: NSObjectProtocol?
@@ -178,8 +183,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         Telemetry.signal("app.launched")
 
-        store.refresh()
-        refreshStatusTitle()
+        poll()
         store.$services
             .receive(on: RunLoop.main)
             .sink { [weak self] services in
@@ -195,11 +199,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.noteRefreshForTelemetry(services)
             }
             .store(in: &cancellables)
-        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+        nextExpectedFire = Date().addingTimeInterval(Self.pollInterval)
+        timer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in
-                self?.store.refresh()
-                self?.refreshStatusTitle()
+                guard let self else { return }
+                let now = Date()
+                let expected = self.nextExpectedFire
+                self.nextExpectedFire = now.addingTimeInterval(Self.pollInterval)
+                // The run loop delivers one immediate catch-up fire on wake. Polling then races the
+                // half-up network and a token that expired mid-sleep, so skip it — the wake observer
+                // schedules the real refresh after its grace delay.
+                guard !WakeScheduling.isOverdueFire(now: now, expected: expected) else { return }
+                self.poll()
             }
+        }
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.scheduleWakeRefresh() }
         }
 
         // Rewrite the statusLine hook script from current code when it's wired, so app upgrades take
@@ -485,6 +502,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NotificationCenter.default.removeObserver(resignObserver)
             self.resignObserver = nil
         }
+    }
+
+    static let pollInterval: TimeInterval = 60
+
+    private func poll() {
+        lastPoll = Date()
+        store.refresh()
+        refreshStatusTitle()
+    }
+
+    /// On wake, hold the first poll for `graceDelay` and only run it if the data is actually
+    /// stale — a short nap needs no off-schedule refresh.
+    private func scheduleWakeRefresh() {
+        wakeRefresh?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                guard WakeScheduling.shouldRefreshAfterWake(lastPoll: self.lastPoll, now: Date(),
+                                                            pollInterval: Self.pollInterval) else { return }
+                self.poll()
+            }
+        }
+        wakeRefresh = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + WakeScheduling.graceDelay, execute: work)
     }
 
     private func refreshStatusTitle() {

--- a/Sources/Mimir/MimirModels.swift
+++ b/Sources/Mimir/MimirModels.swift
@@ -213,14 +213,21 @@ struct ModelStatus: Identifiable {
     let isLow: Bool
     /// Weekly vs session window (Antigravity's grouped rows). `nil` for credit rows.
     let window: ModelWindow?
+    /// Sub-line under a `valueText` row (e.g. "first expires in 3d" under the reset credits count).
+    let caption: String?
+    /// SF Symbol drawn left of a `valueText` row's label. nil → no icon.
+    let symbol: String?
 
-    init(name: String, remainingPercent: Int, resetAt: Date?, valueText: String? = nil, isLow: Bool = false, window: ModelWindow? = nil) {
+    init(name: String, remainingPercent: Int, resetAt: Date?, valueText: String? = nil, isLow: Bool = false,
+         window: ModelWindow? = nil, caption: String? = nil, symbol: String? = nil) {
         self.name = name
         self.remainingPercent = remainingPercent
         self.resetAt = resetAt
         self.valueText = valueText
         self.isLow = isLow
         self.window = window
+        self.caption = caption
+        self.symbol = symbol
     }
 }
 

--- a/Sources/Mimir/PopoverViews.swift
+++ b/Sources/Mimir/PopoverViews.swift
@@ -4,7 +4,6 @@ import SwiftUI
 
 struct PopoverView: View {
     @ObservedObject var store: UsageStore
-    @Environment(\.colorScheme) private var colorScheme
     let onDismiss: () -> Void
     /// Reports the measured content height so AppKit can size the popover.
     /// Plain callback on purpose — see the note at the construction site.
@@ -22,13 +21,9 @@ struct PopoverView: View {
                     VStack(alignment: .leading, spacing: 0) {
                         notificationBanner
                         contentView(now: context.date)
-
-                        sectionDivider
                         BrandingFooter(checkForUpdates: checkForUpdates)
                     }
-                    .padding(.vertical, 8)
-                    .background(innerPanel)
-                    .padding(10)
+                    .padding(.vertical, 4)
                     .background {
                         GeometryReader { proxy in
                             Color.clear
@@ -43,27 +38,6 @@ struct PopoverView: View {
         }
     }
 
-    /// The single panel. Kept very translucent so the frosted desktop reads through it
-    /// like glass — just a faint tint for legibility plus a hairline glass edge.
-    @ViewBuilder
-    private var innerPanel: some View {
-        let dark = colorScheme == .dark
-        RoundedRectangle(cornerRadius: 18, style: .continuous)
-            .fill((dark ? Color(hex: 0x14141C) : Color(hex: 0xFFFFFF)).opacity(dark ? 0.10 : 0.16))
-            .overlay {
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(Color.primary.opacity(dark ? 0.16 : 0.12), lineWidth: 1)
-            }
-    }
-
-    /// A hairline divider between the inner panel's sections, inset from the edges.
-    private var sectionDivider: some View {
-        Rectangle()
-            .fill(Color.primary.opacity(0.06))
-            .frame(height: 1)
-            .padding(.horizontal, 13)
-    }
-
     /// Show live services and stale snapshots; hide services that have no data at all.
     /// A stale Antigravity snapshot (isStale) survives the filter so the user still sees
     /// the last-known reading when the IDE is closed, instead of the card vanishing.
@@ -74,10 +48,16 @@ struct PopoverView: View {
             .filter { ($0.isAvailable || $0.isStale) && !$0.dataUnavailable }
             .sortedByDisplayOrder()
         if !visible.isEmpty {
-            ForEach(Array(visible.enumerated()), id: \.element.id) { index, service in
-                if index > 0 { sectionDivider }
-                ServiceCard(service: service, now: now)
+            // Each provider is its own card — the card border carries the hierarchy, so there are
+            // no dividers or rails between them (design v2.9).
+            VStack(spacing: 11) {
+                ForEach(visible) { service in
+                    ServiceCard(service: service, now: now)
+                }
             }
+            .padding(.horizontal, 11)
+            .padding(.top, 11)
+            .padding(.bottom, 4)
         } else if store.isRefreshing {
             ProgressView()
                 .controlSize(.small)
@@ -141,12 +121,12 @@ struct BrandingFooter: View {
     var body: some View {
         HStack(spacing: 7) {
             Text("mimir")
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(Color.primary.opacity(0.55))
 
             Button { checkForUpdates() } label: {
                 Text(Self.version)
-                    .font(.system(size: 9, weight: .semibold).monospacedDigit())
+                    .font(.system(size: 9, weight: .medium).monospacedDigit())
                     .foregroundStyle(Color.primary.opacity(0.4))
                     .padding(.horizontal, 5)
                     .padding(.vertical, 1.5)
@@ -173,7 +153,10 @@ struct BrandingFooter: View {
             .buttonStyle(.plain)
             .pointingHandCursor()
         }
-        .padding(13)
+        // Line the footer up with the cards above it: "mimir" starts under the card's brand icon
+        // (panel inset 11 + card padding 11), and "milowda" keeps the same margin on the right.
+        .padding(.horizontal, 22)
+        .padding(.vertical, 11)
     }
 }
 
@@ -260,141 +243,186 @@ struct PopoverBackdrop: View {
     }
 }
 
+/// One provider = one card (design v2.9): brand header, its quota block(s), then any
+/// value rows (credit balance, reset credits) below a hairline.
 struct ServiceCard: View {
     let service: ServiceStatus
     let now: Date
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header: white brand glyph + service name.
-            HStack(spacing: 8) {
-                BrandIconView(iconName: service.iconName, size: 15)
-                    .foregroundStyle(Color.primary.opacity(0.92))
-                    .frame(width: 15, height: 15)
-                Text(service.name)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(Color.primary.opacity(0.92))
+            // Provider name as a small uppercase eyebrow — the card frame carries the emphasis,
+            // so the header stays quiet and the quota block is the loudest thing on the card.
+            HStack(spacing: 6) {
+                BrandIconView(iconName: service.iconName, size: 11)
+                    .foregroundStyle(Color.primary.opacity(0.45))
+                    .frame(width: 11, height: 11)
+                Text(cardTitle.uppercased())
+                    .font(.system(size: 10, weight: .medium))
+                    .tracking(0.9)
+                    .foregroundStyle(Color.primary.opacity(0.5))
                     .lineLimit(1)
             }
+            .padding(.bottom, 9)
 
-            if hasServiceQuotas {
-                // Claude / Codex: a single session block, then the weekly rows.
-                ForEach(Array(sessionHeroes.enumerated()), id: \.offset) { index, hero in
-                    SessionRow(label: hero.label, percent: hero.percent, resetAt: hero.resetAt, now: now,
-                               gated: hero.gated, badge: hero.badge, windowFallback: hero.fallback)
-                        .padding(.top, index == 0 ? 11 : 13)
-                }
-                if !weeklyEntries.isEmpty {
-                    VStack(spacing: 6) {
-                        ForEach(Array(weeklyEntries.enumerated()), id: \.offset) { _, entry in
-                            weeklyRow(entry)
-                        }
-                    }
-                    .padding(.top, 11)
-                }
-            } else {
-                // Antigravity: group each family's session and weekly together, so a
-                // family's weekly row sits under its own session — not the next family's.
-                ForEach(Array(antigravityFamilies.enumerated()), id: \.offset) { index, family in
-                    VStack(alignment: .leading, spacing: 0) {
-                        if let session = family.session {
-                            SessionRow(label: family.name, percent: session.percent, resetAt: session.resetAt, now: now,
-                                       gated: family.weekly?.percent == 0)
-                        }
-                        if let weekly = family.weekly {
-                            weeklyRow((label: family.name, percent: weekly.percent, resetAt: weekly.resetAt,
-                                       windowSeconds: nil))
-                                .padding(.top, family.session != nil ? 8 : 0)
-                        }
-                    }
-                    .padding(.top, index == 0 ? 11 : 13)
-                }
-            }
-
-            if let credit = creditEntry {
-                HStack {
-                    Text(credit.label)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(Color.primary.opacity(0.4))
-                    Spacer()
-                    Text(credit.value)
-                        .font(.system(size: 11, weight: .semibold).monospacedDigit())
-                        .foregroundStyle(Color.primary.opacity(0.7))
-                }
-                .padding(.top, 11)
-            }
+            cardBody
         }
-        .padding(13)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(11)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(.regularMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                )
+        )
         // Dim a stale snapshot so it reads as "last known, not live".
         .opacity(service.isStale ? 0.66 : 1)
     }
 
-    /// Badge text for a quota window, built from its REAL length ("7g", "30g"). nil when the provider
-    /// doesn't report one, so the caller keeps its plain weekly label rather than printing a guess.
-    private func windowBadge(_ seconds: TimeInterval?) -> String? {
-        quotaWindowDays(seconds).map { "\($0)\(TimeFormatter.dayUnit)" }
+    /// Everything under the header, inset from the card edge (design: 11px, no rail).
+    @ViewBuilder
+    private var cardBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if hasServiceQuotas {
+                // Claude / Codex: one quota block, then the per-model rows under it.
+                if let hero = sessionHero {
+                    QuotaBlock(label: hero.label, percent: hero.percent, resetAt: hero.resetAt, now: now,
+                               gated: hero.gated, windowFallback: hero.fallback)
+                }
+                if !weeklyEntries.isEmpty {
+                    VStack(spacing: 5) {
+                        ForEach(Array(weeklyEntries.enumerated()), id: \.offset) { _, entry in
+                            modelRow(entry)
+                        }
+                    }
+                    .padding(.top, 9)
+                }
+            } else {
+                // Antigravity: one card, one section per family, separated by a hairline so a
+                // family's model row sits under its own block — not the next family's.
+                ForEach(Array(antigravityFamilies.enumerated()), id: \.offset) { index, family in
+                    VStack(alignment: .leading, spacing: 0) {
+                        if index > 0 {
+                            cardDivider.padding(.top, 13).padding(.bottom, 13)
+                        }
+                        if let session = family.session {
+                            QuotaBlock(label: family.name, percent: session.percent, resetAt: session.resetAt,
+                                       now: now, gated: family.weekly?.percent == 0)
+                        }
+                        if let weekly = family.weekly {
+                            modelRow((label: family.name, percent: weekly.percent, resetAt: weekly.resetAt))
+                                .padding(.top, family.session != nil ? 9 : 0)
+                        }
+                    }
+                }
+            }
+
+            if !valueRows.isEmpty {
+                cardDivider.padding(.top, 11).padding(.bottom, 9)
+                VStack(alignment: .leading, spacing: 7) {
+                    ForEach(valueRows) { row in
+                        valueRow(row)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 11)
     }
 
-    private func weeklyRow(_ entry: (label: String, percent: Int, resetAt: Date?, windowSeconds: TimeInterval?)) -> some View {
-        // The 7g dot uses the weekly bands (amber ≥10%, red below) — at 0% it stays red here; it's the
-        // 5s session that greys out to flag the lockout (see SessionRow `gated`).
+    private var cardDivider: some View {
+        Rectangle()
+            .fill(Color.primary.opacity(0.07))
+            .frame(height: 1)
+    }
+
+    /// A secondary quota row: status dot + "Name: %X" + its remaining time on the right.
+    private func modelRow(_ entry: (label: String, percent: Int, resetAt: Date?)) -> some View {
         HStack(spacing: 8) {
             Circle()
-                .fill(quotaStatusColor(entry.percent, redBelow: 10))
+                .fill(quotaStatusColor(entry.percent))
                 .frame(width: 7, height: 7)
-            Text(entry.label)
-                .font(.system(size: 11, weight: .regular))
-                .foregroundStyle(Color.primary.opacity(0.62))
-                .lineLimit(1)
-            QuotaBadge(text: windowBadge(entry.windowSeconds) ?? String(localized: "7g"))
+            Text("\(entry.label): ").font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Color.primary.opacity(0.72))
+                + Text("%\(clampPct(entry.percent))").font(.system(size: 11, weight: .medium).monospacedDigit())
+                .foregroundStyle(Color.primary.opacity(0.9))
             Spacer(minLength: 6)
-            Text("%\(clampPct(entry.percent))")
-                .font(.system(size: 11, weight: .semibold).monospacedDigit())
-                .foregroundStyle(Color.primary.opacity(0.62))
             Text(relDuration(entry.resetAt, now) ?? "—")
-                .font(.system(size: 11, weight: .regular).monospacedDigit())
-                .foregroundStyle(Color.primary.opacity(0.38))
-                .frame(width: 52, alignment: .trailing)
+                .font(.system(size: 11, weight: .medium).monospacedDigit())
+                .foregroundStyle(Color.primary.opacity(0.42))
+                .fixedSize()
         }
+        .lineLimit(1)
+    }
+
+    /// A value row (credit balance, reset credits): icon + label left, value right, optional caption.
+    private func valueRow(_ row: ModelStatus) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                HStack(spacing: 5) {
+                    if let symbol = row.symbol {
+                        Image(systemName: symbol).font(.system(size: 11, weight: .regular))
+                    }
+                    Text(row.name)
+                }
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Color.primary.opacity(0.58))
+                Spacer(minLength: 6)
+                Text(row.valueText ?? "")
+                    .font(.system(size: 11, weight: .medium).monospacedDigit())
+                    .foregroundStyle(Color.primary.opacity(0.9))
+            }
+            if let caption = row.caption {
+                Text(caption)
+                    .font(.system(size: 10, weight: .medium).monospacedDigit())
+                    .foregroundStyle(Color.primary.opacity(0.42))
+            }
+        }
+        .lineLimit(1)
     }
 
     // MARK: Data shaping
 
-    /// Weekly rows. Claude/Codex: the all-models weekly (labelled with the service name)
-    /// plus any per-model weekly (e.g. Sonnet). Antigravity: its grouped weekly buckets.
-    private var weeklyEntries: [(label: String, percent: Int, resetAt: Date?, windowSeconds: TimeInterval?)] {
-        if hasServiceQuotas {
-            var out: [(label: String, percent: Int, resetAt: Date?, windowSeconds: TimeInterval?)] = []
-            // The account weekly is a row only when there IS a 5h session above it; with no session the
-            // weekly is promoted into the hero block (see sessionHeroes), so don't repeat it here.
-            if service.sessionRemainingPercent != nil, let weekly = service.weeklyRemainingPercent {
-                out.append((service.name, weekly, service.weeklyResetAt, service.weeklyWindowSeconds))
-            }
-            // Per-model weeklies carry no length of their own — they keep the plain weekly badge.
-            for model in service.models where model.valueText == nil {
-                out.append((model.name, model.remainingPercent, model.resetAt, nil))
-            }
-            return out
-        }
-        return service.models
-            .filter { $0.window == .weekly && $0.valueText == nil }
-            .map { (label: $0.name, percent: $0.remainingPercent, resetAt: $0.resetAt, windowSeconds: nil) }
+    /// Codex is branded "ChatGPT" on the card — that's the account the quota belongs to.
+    private var cardTitle: String {
+        service.name == "Codex" ? "ChatGPT" : service.name
     }
 
-    /// The prominent block (Claude/Codex — one each). Normally the 5-hour session; but when a service
-    /// has no 5h window (Codex since OpenAI's July 2026 removal) the weekly reading is promoted here
-    /// with a "7g" badge so the card still shows a clear number instead of a bare row.
-    private var sessionHeroes: [(label: String, percent: Int, resetAt: Date?, badge: String, fallback: TimeInterval, gated: Bool)] {
+    /// Model rows under the quota block. Claude/Codex: the account weekly ("All models") plus any
+    /// per-model weekly (e.g. Fable). Antigravity groups its own, per family.
+    private var weeklyEntries: [(label: String, percent: Int, resetAt: Date?)] {
+        var out: [(label: String, percent: Int, resetAt: Date?)] = []
+        // The account weekly is a row only when there IS a 5h block above it; with no session the
+        // weekly is promoted into the block (see sessionHero), so don't repeat it here.
+        if service.sessionRemainingPercent != nil, let weekly = service.weeklyRemainingPercent {
+            out.append((String(localized: "All models"), weekly, service.weeklyResetAt))
+        }
+        for model in service.models where model.valueText == nil {
+            out.append((model.name, model.remainingPercent, model.resetAt))
+        }
+        return out
+    }
+
+    /// The card's prominent block (Claude/Codex). Normally the 5-hour session; when a service has no
+    /// 5h window (Codex since OpenAI's July 2026 removal) the weekly reading is promoted here, under
+    /// a label that says so, rather than leaving the card without a headline number.
+    private var sessionHero: (label: String, percent: Int, resetAt: Date?, fallback: TimeInterval, gated: Bool)? {
         if let session = service.sessionRemainingPercent {
-            return [(service.name, session, service.sessionResetAt,
-                     String(localized: "5s"), 5 * 3600, service.weeklyRemainingPercent == 0)]
+            return (String(localized: "Current session"), session, service.sessionResetAt,
+                    5 * 3600, service.weeklyRemainingPercent == 0)
         }
         if let weekly = service.weeklyRemainingPercent {
-            return [(service.name, weekly, service.weeklyResetAt,
-                     windowBadge(service.weeklyWindowSeconds) ?? String(localized: "7g"),
-                     service.weeklyWindowSeconds ?? 7 * 24 * 3600, false)]
+            return (String(localized: "Usage limits"), weekly, service.weeklyResetAt,
+                    service.weeklyWindowSeconds ?? 7 * 24 * 3600, false)
         }
-        return []
+        return nil
+    }
+
+    /// Credit / reset-credit rows, in provider order. Empty → the whole section is skipped.
+    private var valueRows: [ModelStatus] {
+        service.models.filter { $0.valueText != nil }
     }
 
     /// Antigravity grouped by family, preserving first-seen order, each family carrying
@@ -418,12 +446,6 @@ struct ServiceCard: View {
         }
     }
 
-    private var creditEntry: (label: String, value: String)? {
-        guard let model = service.models.first(where: { $0.valueText != nil }),
-              let value = model.valueText else { return nil }
-        return (String(localized: "Usage credit"), value)
-    }
-
     private var hasServiceQuotas: Bool {
         service.name == "Claude" || service.name == "Codex"
     }
@@ -443,27 +465,9 @@ func relDuration(_ resetAt: Date?, _ now: Date) -> String? {
     return TimeFormatter.duration(from: resetAt.timeIntervalSince(now))
 }
 
-/// A small grey pill badge (e.g. "5s" for the 5-hour session, "7g" for the weekly window).
-struct QuotaBadge: View {
-    let text: String
-    var prominent = false
-
-    var body: some View {
-        Text(text)
-            .font(.system(size: prominent ? 10 : 9.5, weight: .semibold))
-            .foregroundStyle(Color.primary.opacity(0.34))
-            .padding(.horizontal, prominent ? 5 : 4.5)
-            .padding(.vertical, prominent ? 1.5 : 1)
-            .background(
-                RoundedRectangle(cornerRadius: prominent ? 5 : 4, style: .continuous)
-                    .fill(Color.primary.opacity(0.06))
-            )
-    }
-}
-
-/// The prominent session block: model name + "5s" badge + big status-coloured percent,
-/// a thin status-coloured bar, then remaining time (left) and reset clock (right).
-struct SessionRow: View {
+/// A quota block: window label + status-coloured percent on one line, a thin status-coloured
+/// bar, then remaining time (left) and reset clock (right).
+struct QuotaBlock: View {
     let label: String
     let percent: Int
     let resetAt: Date?
@@ -471,9 +475,6 @@ struct SessionRow: View {
     /// True when this model's weekly quota is spent — grey the figure + bar so a full 5h window
     /// can't masquerade as usable while the week is locked.
     var gated: Bool = false
-    /// Window badge — "5s" for the 5-hour session, "7g" when a weekly reading is promoted here
-    /// (a service with no 5h window, e.g. Codex since the July 2026 removal).
-    var badge: String = String(localized: "5s")
     /// Reset-countdown fallback length shown when there's no `resetAt`, matching this window (5h vs 7d).
     var windowFallback: TimeInterval = 5 * 3600
 
@@ -483,20 +484,19 @@ struct SessionRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
+            HStack(spacing: 8) {
                 Text(label)
-                    .font(.system(size: 12.5, weight: .semibold))
-                    .foregroundStyle(Color.primary.opacity(0.88))
+                    .font(.system(size: 13.5, weight: .medium))
+                    .foregroundStyle(Color.primary.opacity(0.9))
                     .lineLimit(1)
-                QuotaBadge(text: badge, prominent: true)
                 Spacer(minLength: 6)
                 Text("%\(clampPct(percent))")
-                    .font(.system(size: 18, weight: .semibold).monospacedDigit())
+                    .font(.system(size: 13.5, weight: .medium).monospacedDigit())
                     .foregroundStyle(gated ? lockedQuotaColor : quotaStatusColor(percent))
             }
 
             QuotaBar(percent: percent, colorOverride: gated ? lockedQuotaColor : nil)
-                .padding(.top, 9)
+                .padding(.top, 8)
 
             HStack(spacing: 8) {
                 Label {
@@ -504,7 +504,7 @@ struct SessionRow: View {
                     // full window length rather than a bare dash.
                     Text(relDuration(resetAt, now) ?? TimeFormatter.duration(from: windowFallback))
                 } icon: {
-                    Image(systemName: "gauge.medium")
+                    Image(systemName: "hourglass")
                 }
                 Spacer(minLength: 4)
                 if let resetClock {
@@ -516,9 +516,9 @@ struct SessionRow: View {
                 }
             }
             .font(.system(size: 11, weight: .medium).monospacedDigit())
-            .foregroundStyle(Color.primary.opacity(0.42))
+            .foregroundStyle(Color.primary.opacity(0.5))
             .labelStyle(.titleAndIcon)
-            .padding(.top, 6)
+            .padding(.top, 7)
         }
     }
 
@@ -547,16 +547,15 @@ struct QuotaBar: View {
     }
 }
 
-/// Status colour for a remaining-quota level: green ≥50%, amber down to `redBelow`, red under it.
-/// The amber→red boundary differs by window — 15% for the 5-hour session, 10% for the weekly (7g)
-/// window (its lower band is intentionally looser). Returns a dynamic colour that darkens in light
-/// mode so it stays legible on the light panel.
-func quotaStatusColor(_ percent: Int, redBelow: Int = 15) -> Color {
+/// Status colour for a remaining-quota level, per the design spec's thresholds: green ≥50%,
+/// amber 15–49%, red ≤14% — one set of bands for every window. Returns a dynamic colour that
+/// darkens in light mode so it stays legible on the light panel.
+func quotaStatusColor(_ percent: Int) -> Color {
     let darkHex: UInt32, lightHex: UInt32
     switch clampPct(percent) {
-    case 50...100:                  darkHex = 0x3FB984; lightHex = 0x1F9E63  // green
-    case let p where p >= redBelow: darkHex = 0xE0A93C; lightHex = 0xB07E1C  // amber
-    default:                        darkHex = 0xE5564E; lightHex = 0xCF3A33  // red
+    case 50...100: darkHex = 0x3FB984; lightHex = 0x1FA45E  // green
+    case 15...49:  darkHex = 0xE0A93C; lightHex = 0xB07D0A  // amber
+    default:       darkHex = 0xE5564E; lightHex = 0xC9403A  // red
     }
     return Color(nsColor: NSColor(name: nil) { appearance in
         let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua

--- a/Sources/Mimir/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/en.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "5h session · %@" = "5h session · %@";
 "All models" = "All models";
 "Usage credit" = "Usage credit";
+"Usage limits" = "Usage limits";
+"Credit balance" = "Credit balance";
+"Reset credits" = "Reset credits";
+"first expires in %@" = "first expires in %@";
+"AI credit" = "AI credit";
 "Resets at %@" = "Resets at %@";
 
 /* Tooltip / status */
@@ -54,9 +59,6 @@
 "no local source" = "no local source";
 
 /* Credit / billing labels */
-"Google One credits" = "Google One credits";
-"Billing" = "Billing";
-"Credits" = "Credits";
 "Unlimited" = "Unlimited";
 "%@ credits" = "%@ credits";
 

--- a/Sources/Mimir/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/tr.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "5h session · %@" = "5 saatlik oturum · %@";
 "All models" = "Tüm modeller";
 "Usage credit" = "Kullanım kredisi";
+"Usage limits" = "Kullanım limitleri";
+"Credit balance" = "Kredi bakiyesi";
+"Reset credits" = "Sıfırlama hakkı";
+"first expires in %@" = "ilki %@ sonra doluyor";
+"AI credit" = "AI kredisi";
 "Resets at %@" = "%@'da sıfırlanır";
 
 /* Tooltip / status */
@@ -54,9 +59,6 @@
 "no local source" = "yerel kaynak yok";
 
 /* Credit / billing labels */
-"Google One credits" = "Google One kredisi";
-"Billing" = "Fatura";
-"Credits" = "Kredi";
 "Unlimited" = "Sınırsız";
 "%@ credits" = "%@ kredi";
 

--- a/Sources/Mimir/WakeScheduling.swift
+++ b/Sources/Mimir/WakeScheduling.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Pure decisions for polling around sleep/wake. Adapted from codex-island (MIT).
+/// No AppKit or store dependencies so the boundaries stay unit-testable.
+enum WakeScheduling {
+    /// How late a repeating-timer fire must be before we call it a wake catch-up rather than
+    /// run-loop jitter. Tolerance and a busy main thread account for seconds; only sleep
+    /// accounts for minutes.
+    static let overdueSlack: TimeInterval = 120
+
+    /// How long after wake to hold the first poll: long enough for Wi-Fi to re-associate,
+    /// for the reconnect burst of dormant sessions to pass, and for a token that expired
+    /// mid-sleep to be refreshable; short enough to update within the first minute.
+    static let graceDelay: TimeInterval = 60
+
+    /// True when a repeating-timer fire arrives so far past its schedule that the machine must
+    /// have slept through the fire date. The run loop delivers exactly one immediate catch-up
+    /// fire on wake — polling right then races the half-up network and the wake burst, which is
+    /// how "rate limited" / "token expired" land as the lid opens.
+    static func isOverdueFire(now: Date, expected: Date?) -> Bool {
+        guard let expected else { return false }
+        return now.timeIntervalSince(expected) > overdueSlack
+    }
+
+    /// Whether a wake warrants an off-schedule refresh. A lid flip after a short nap doesn't —
+    /// the data is still fresher than one poll interval.
+    static func shouldRefreshAfterWake(lastPoll: Date?, now: Date, pollInterval: TimeInterval) -> Bool {
+        guard let lastPoll else { return true }
+        return now.timeIntervalSince(lastPoll) >= pollInterval
+    }
+}

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -113,6 +113,75 @@ final class UsageParsingTests: XCTestCase {
         XCTAssertNil(quotaWindowDays(TimeInterval?.none))   // unknown → no badge
     }
 
+    /// The live `wham/usage` response observed 2026-08-04 on a Plus account (identifiers redacted),
+    /// parsed through JSONSerialization so the numbers arrive as NSNumber exactly as in production.
+    func testCodexStatusFromLiveWeeklyOnlyResponse() {
+        let json = """
+        {
+          "plan_type": "plus",
+          "rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+              "used_percent": 40,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 332661,
+              "reset_at": 1786161248
+            },
+            "secondary_window": null
+          },
+          "credits": { "has_credits": false, "unlimited": false }
+        }
+        """
+        let root = try! JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
+        let status = ds.codexStatus(fromUsageRoot: root)
+        XCTAssertNil(status.sessionRemainingPercent)
+        XCTAssertEqual(status.weeklyRemainingPercent, 60)
+        XCTAssertEqual(status.weeklyResetAt, Date(timeIntervalSince1970: 1_786_161_248))
+        XCTAssertEqual(status.weeklyWindowSeconds, 604_800)
+        XCTAssertTrue(status.models.isEmpty)
+    }
+
+    // MARK: Codex reset credits
+
+    private func resetCreditsRoot(_ credits: String) -> [String: Any] {
+        let json = "{\"available_count\": 2, \"credits\": [\(credits)]}"
+        return try! JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
+    }
+
+    private let credalNow = Date(timeIntervalSince1970: 1_786_000_000)
+    private func iso(_ offset: TimeInterval) -> String {
+        ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: 1_786_000_000 + offset))
+    }
+
+    /// Available and unexpired credits are counted, with the nearest expiry in the caption.
+    func testCodexResetCreditsCountsAvailableOnes() {
+        let root = resetCreditsRoot("""
+        {"id": "a", "status": "available", "expires_at": "\(iso(6 * 86_400))", "title": "Reset", "description": ""},
+        {"id": "b", "status": "available", "expires_at": "\(iso(3 * 86_400))", "title": "Reset", "description": ""}
+        """)
+        let row = ds.codexResetCreditRow(fromRoot: root, now: credalNow)
+        XCTAssertEqual(row?.valueText, "2")
+        XCTAssertEqual(row?.caption, String(format: String(localized: "first expires in %@"),
+                                            TimeFormatter.duration(from: 3 * 86_400)))
+    }
+
+    /// A credit that lapsed between polls, and one that was already spent, are both dropped —
+    /// `available_count` alone would have over-reported here.
+    func testCodexResetCreditsDropsExpiredAndUsed() {
+        let root = resetCreditsRoot("""
+        {"id": "a", "status": "available", "expires_at": "\(iso(-3_600))", "title": "", "description": ""},
+        {"id": "b", "status": "used", "expires_at": "\(iso(30 * 86_400))", "title": "", "description": ""}
+        """)
+        XCTAssertNil(ds.codexResetCreditRow(fromRoot: root, now: credalNow))
+    }
+
+    /// Empty / missing payload → no row at all, so the card simply doesn't draw the section.
+    func testCodexResetCreditsEmptyPayload() {
+        XCTAssertNil(ds.codexResetCreditRow(fromRoot: ["available_count": 0, "credits": []]))
+        XCTAssertNil(ds.codexResetCreditRow(fromRoot: [:]))
+    }
+
     /// Both windows present with real durations: the 5-hour one (limit_window_seconds 18000) is the
     /// session, the 7-day one (604800) is weekly — classified by duration regardless of slot.
     func testCodexStatusClassifiesBothWindowsByDuration() {
@@ -385,7 +454,7 @@ final class UsageParsingTests: XCTestCase {
             ],
         ]
         let status = ds.buildClaudeStatus(from: root, note: "oauth usage api")
-        let billing = status.models.first { $0.name == "Billing" }
+        let billing = status.models.first { $0.valueText != nil }
         XCTAssertEqual(billing?.valueText, "5 USD / 10 USD")
     }
 

--- a/Tests/MimirTests/WakeSchedulingTests.swift
+++ b/Tests/MimirTests/WakeSchedulingTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import Mimir
+
+/// The sleep/wake poll guard: a fire minutes late is the run loop's catch-up after sleep (skip it),
+/// a fire seconds late is jitter (poll normally); and a short nap doesn't earn an extra refresh.
+final class WakeSchedulingTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testOverdueFireBoundary() {
+        XCTAssertFalse(WakeScheduling.isOverdueFire(now: now, expected: nil))            // first fire
+        XCTAssertFalse(WakeScheduling.isOverdueFire(now: now, expected: now))            // on time
+        XCTAssertFalse(WakeScheduling.isOverdueFire(now: now, expected: now - 5))        // jitter
+        XCTAssertFalse(WakeScheduling.isOverdueFire(now: now, expected: now - 120))      // exactly slack
+        XCTAssertTrue(WakeScheduling.isOverdueFire(now: now, expected: now - 121))       // just past it
+        XCTAssertTrue(WakeScheduling.isOverdueFire(now: now, expected: now - 3600))      // slept an hour
+    }
+
+    func testRefreshAfterWakeOnlyWhenDataIsStale() {
+        XCTAssertTrue(WakeScheduling.shouldRefreshAfterWake(lastPoll: nil, now: now, pollInterval: 60))
+        XCTAssertFalse(WakeScheduling.shouldRefreshAfterWake(lastPoll: now - 59, now: now, pollInterval: 60))
+        XCTAssertTrue(WakeScheduling.shouldRefreshAfterWake(lastPoll: now - 60, now: now, pollInterval: 60))
+        XCTAssertTrue(WakeScheduling.shouldRefreshAfterWake(lastPoll: now - 7200, now: now, pollInterval: 60))
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [2.9] - 2026-08-14
+
+#### Added
+- **Extra credit you've bought** is now shown for all three providers, each under its own name — "Usage credit" for Claude, "Credit balance" for ChatGPT, "AI credit" for Antigravity. When there's no credit, the row isn't shown at all.
+- ChatGPT also shows your **reset credits**: how many you have and how long before the first one expires. When you have none, the row isn't shown at all.
+
+#### Changed
+- Visual improvements throughout: every provider now sits in its own card, so the popover is easier to read.
+- The Codex card is now called **ChatGPT** — that's the account the quota belongs to.
+- Window and model names now match what each provider calls them, so the rows read the way you're used to seeing them.
+- The window badges ("5h", "7d") are gone: the remaining time already says which window you're looking at, and the row is calmer without them.
+
+#### Fixed
+- Waking your Mac no longer causes a "rate limited" or "token expired" reading. The refresh that used to fire the instant the lid opened — racing the Wi-Fi reconnect and a token that expired during sleep — now waits a minute, and is skipped entirely after a short nap.
+- Claude's spending row uses the API's own severity when it reports one, instead of always inferring "low" from 80% of the cap.
+
 ### [2.8] - 2026-08-09
 
 #### Fixed
@@ -384,6 +400,22 @@ Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
 
 ### [Yayımlanmadı]
+
+### [2.9] - 2026-08-14
+
+#### Eklendi
+- Satın alınan **ekstra kredi** artık üç sağlayıcı için de gösteriliyor; her biri kendi adıyla — Claude'da "Kullanım kredisi", ChatGPT'de "Kredi bakiyesi", Antigravity'de "AI kredisi". Kredi yoksa satır hiç gösterilmiyor.
+- ChatGPT için ayrıca **sıfırlama hakkı** geldi: kaç hakkın olduğu ve ilkinin ne kadar süre sonra dolacağı yazıyor. Hak yoksa satır hiç gösterilmiyor.
+
+#### Değişti
+- Görünümde iyileştirmeler yapıldı: artık her sağlayıcı kendi kartında, popover'ı okumak daha kolay.
+- Codex kartının adı artık **ChatGPT** — kota o hesaba ait.
+- Pencere ve model isimleri sağlayıcıların kendi kullandığı, alışık olduğunuz isimlere çevrildi.
+- Pencere rozetleri ("5s", "7g") kaldırıldı: hangi pencereye baktığınız zaten kalan süreden belli, rozetsiz satır daha sakin.
+
+#### Düzeltildi
+- Mac uykudan uyanınca artık "kota aşıldı" ya da "token süresi doldu" okuması gelmiyor. Kapak açılır açılmaz tetiklenen — Wi-Fi'ın yeniden bağlanmasıyla ve uykuda süresi dolmuş bir token'la yarışan — yenileme artık bir dakika bekliyor, kısa şekerlemelerden sonra ise hiç çalışmıyor.
+- Claude'un harcama satırı, API kendi önem derecesini bildirdiğinde onu kullanıyor; her seferinde limitin %80'inden "düşük" çıkarımı yapmıyor.
 
 ### [2.8] - 2026-08-09
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -58,7 +58,9 @@ Mimir shows session and weekly quotas for **Codex**, trying two sources in order
 
 > 📝 **Note:** If no reset time is found in the local file, the card still shows the remaining percentage, but the countdown may be omitted (the card notes this).
 
-**What's shown.** Session (5-hour) and weekly remaining percentages with reset times. When available, value rows such as a **credit balance** (for these non-percentage rows, Mimir triggers the low-quota badge when they fall below their threshold).
+**Reset credits.** Alongside the balance, Codex can hold **reset credits** — one-shot passes that clear a spent rate-limit window. Mimir reads them from the ChatGPT API and shows how many you have, plus how long until the first one expires. Only credits that are both still available and not yet expired are counted (one can lapse between polls), and the row is omitted entirely when there are none. This is a bonus reading: if the request fails, the rest of the Codex card is unaffected.
+
+**What's shown.** Session (5-hour) and weekly remaining percentages with reset times. When available, value rows such as the **credit balance** and **reset credits** (for these non-percentage rows, Mimir triggers the low-quota badge when they fall below their threshold).
 
 | Symptom | Likely cause / fix |
 |---|---|
@@ -144,7 +146,9 @@ Mimir, **Codex** için seans ve haftalık kotaları gösterir. İki kaynağı s�
 
 > 📝 **Not:** Yerel dosyada sıfırlanma zamanı bulunamazsa kart yine kalan yüzdeyi gösterir, ancak geri sayım gösterilmeyebilir (kart bunu bir notla belirtir).
 
-**Gösterilen bilgiler.** Seans (5 saatlik) ve haftalık kalan yüzdeleri ile sıfırlanma zamanları. Uygun olduğunda **kredi bakiyesi** gibi değer satırları (yüzde olmayan bu satırlar için Mimir, eşik altına inildiğinde düşük-kota rozetini tetikler).
+**Sıfırlama hakkı.** Bakiyenin yanında Codex'te **sıfırlama hakkı** olabilir — dolan bir kota penceresini temizleyen tek kullanımlık haklar. Mimir bunları ChatGPT API'sinden okur; kaç tane olduğunu ve ilkinin ne kadar süre sonra dolacağını gösterir. Yalnızca hem hâlâ kullanılabilir hem de süresi dolmamış haklar sayılır (bir hak iki sorgu arasında süresini doldurabilir); hiç yoksa satır hiç çizilmez. Bu ek bir okumadır: istek başarısız olursa Codex kartının geri kalanı etkilenmez.
+
+**Gösterilen bilgiler.** Seans (5 saatlik) ve haftalık kalan yüzdeleri ile sıfırlanma zamanları. Uygun olduğunda **kredi bakiyesi** ve **sıfırlama hakkı** gibi değer satırları (yüzde olmayan bu satırlar için Mimir, eşik altına inildiğinde düşük-kota rozetini tetikler).
 
 | Belirti | Olası neden / çözüm |
 |---|---|


### PR DESCRIPTION
## What

- **Popover**: one card per provider (design v2.9) — quiet uppercase provider label, quota block with its percentage on the label line, model rows as "Name: %X", credit rows below a hairline. Window pills, provider dividers, the extra panel frame and every bold weight are gone.
- **ChatGPT reset credits**: read from `wham/rate-limit-reset-credits`, counting only credits that are still available and unexpired, with the nearest expiry as a caption. Row omitted when there are none; a failed request never affects the rest of the card.
- **Credit rows are labelled per provider**: "Usage credit" (Claude), "Credit balance" / "Reset credits" (ChatGPT), Antigravity's row takes its name from the credit type instead of always saying "Google One".
- **Wake-safe polling** (`WakeScheduling`, adapted from codex-island, MIT): the run loop's catch-up fire after sleep is skipped, and the post-wake refresh waits 60s and is dropped entirely after a short nap — so the lid opening no longer races the Wi-Fi reconnect and a token that expired during sleep.
- Claude's spending row uses the API's own `severity` when present instead of the 80%-of-cap heuristic.
- Status colours unified on the design spec's thresholds (green ≥50, amber 15–49, red ≤14).

## Test

- `swift test` — 90/90 (new: `WakeSchedulingTests` boundaries, reset-credit parse fixtures available/expired/empty, live 2026-08-04 `wham/usage` fixture).
- `BUILD_ONLY=1 ./script/release.sh 0.0` — app + widget build.
- Visual check on the dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)