### PR TITLE
fix(telemetry): send to the correct TelemetryDeck app id

### DIFF
--- a/Sources/Mimir/Telemetry.swift
+++ b/Sources/Mimir/Telemetry.swift
@@ -7,7 +7,7 @@ import TelemetryDeck
 enum Telemetry {
     /// TelemetryDeck app id — non-secret, embedded in the client (like the Sentry DSN). Empty →
     /// `start()` is a no-op. Namespace scopes signals to our org on the ingestion side.
-    static let appID = "BB8EDF61-7FE8-48E9-897B-44C2F3B85277"
+    static let appID = "451C5BEF-443E-42ED-960A-513679A23DAE"
     static let namespace = "com.milowda"
 
     static let enabledKey = "telemetry.enabled"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [2.10] - 2026-08-16
+
+#### Fixed
+- Anonymous usage telemetry was being sent to the wrong destination since 2.5.3, so none of it ever arrived. The signals themselves were unchanged — categorical only, no quota values, no account data — they simply went nowhere. Opting out still works exactly as before.
+
 ### [2.9] - 2026-08-14
 
 #### Added
@@ -400,6 +405,11 @@ Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
 
 ### [Yayımlanmadı]
+
+### [2.10] - 2026-08-16
+
+#### Düzeltildi
+- Anonim kullanım telemetrisi 2.5.3'ten beri yanlış hedefe gönderiliyordu, dolayısıyla hiçbiri ulaşmadı. Gönderilen sinyaller değişmedi — yalnızca kategorik, kota değeri veya hesap bilgisi içermiyor — sadece hiçbir yere gitmiyorlardı. Kapatma tercihi eskisi gibi çalışıyor.
 
 ### [2.9] - 2026-08-14
 


### PR DESCRIPTION
## Problem

The app id embedded in `Telemetry.swift` is not the one TelemetryDeck issued for this app:

```
in code:    BB8EDF61-7FE8-48E9-897B-44C2F3B85277
dashboard:  451C5BEF-443E-42ED-960A-513679A23DAE
```

Wrong since `7453ca3` (2026-06-26), shipped from **2.5.3** onward. The dashboard reads `Users 0`, `Most used SDK Unknown`, `Errors 0` — nothing has ever arrived.

## What was ruled out first

- **Namespace** — `com.milowda` matches the org namespace on the dashboard. The SDK does route namespaced signals to `v2/namespace/com.milowda/` instead of `v2/`, but that endpoint is live and correct.
- **Sandbox / network entitlement** — the app is not sandboxed (`codesign -d --entitlements` shows only application-identifier and application-groups), so outbound requests are unrestricted.
- **Opt-out gate** — `shouldSend(isDev:enabled:)` is pure and unit-tested; `telemetry.enabled` defaults to on and is unset locally.
- **Dev builds** — `isDevBuild` correctly suppresses `com.erayendes.mimir.dev`. This is why the maintainer's own machine sends nothing: the running process is the dev build, not `/Applications/Mimir.app`.

Signals were leaving the machine the whole time. They were addressed to the wrong app.

## Fix

One constant. No behaviour change: the signal set, the categorical-only payloads, and the opt-out path are untouched.

## No test

The value is a constant validated against an external dashboard. A unit test could only assert the constant equals itself, which would not have caught this and will not catch the next one. The real check is the dashboard showing traffic after this ships.

## Verification

- `swift build` clean, `swift test` 90 passed
- Release-note extraction for 2.10 tested with the workflow's own awk: both EN and TR resolve
- `build_number.sh 2.10` → `2010000` (> 2.9's `2009000`)

Not tagged — releasing is the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)