### PR TITLE
fix(antigravity): try every running language server, not just the first

### DIFF
--- a/Sources/Mimir/AntigravityProvider.swift
+++ b/Sources/Mimir/AntigravityProvider.swift
@@ -99,50 +99,61 @@ extension LiveUsageDataSource {
     /// Locate the running Antigravity language server and return its CSRF token plus the
     /// localhost ports it listens on. Shared by every local-gRPC fetch so the process /
     /// port discovery (and its lsof gotcha) lives in one place.
-    private func antigravityLanguageServerEndpoint() -> (csrf: String, ports: [Int])? {
-        let processRows = runShell("ps -ax -o pid=,command= | grep 'bin/language_server' | grep antigravity | grep -v grep")
+    private func antigravityLanguageServerEndpoints() -> [(csrf: String, ports: [Int])] {
+        runShell("ps -ax -o pid=,command= | grep 'bin/language_server' | grep antigravity | grep -v grep")
             .split(separator: "\n")
-        guard let row = processRows.first else {
-            return nil
-        }
-        let command = String(row)
-        guard let pidStr = command.split(separator: " ").first.map(String.init),
-              let pidInt = Int(pidStr),
-              let csrf = extractFlag("--csrf_token", from: command) else {
-            return nil
-        }
+            .compactMap { row in
+                let command = String(row)
+                guard let pidStr = command.split(separator: " ").first.map(String.init),
+                      let pidInt = Int(pidStr),
+                      let csrf = extractFlag("--csrf_token", from: command) else {
+                    return nil
+                }
 
-        // -a ANDs the filters; without it lsof ORs -iTCP and -p, returning every
-        // listening port on the system and forcing dozens of curl probes that blow the timeout.
-        let ports = runShell("lsof -a -nP -iTCP -sTCP:LISTEN -p \(pidInt) | awk '{print $9}' | sed -E 's/.*:([0-9]+)->?.*/\\1/' | sed -E 's/.*:([0-9]+)$/\\1/' | sort -u")
-            .split(separator: "\n")
-            .compactMap { Int($0) }
-        guard !ports.isEmpty else {
-            return nil
+                // -a ANDs the filters; without it lsof ORs -iTCP and -p, returning every
+                // listening port on the system and forcing dozens of curl probes that blow the timeout.
+                let ports = runShell("lsof -a -nP -iTCP -sTCP:LISTEN -p \(pidInt) | awk '{print $9}' | sed -E 's/.*:([0-9]+)->?.*/\\1/' | sed -E 's/.*:([0-9]+)$/\\1/' | sort -u")
+                    .split(separator: "\n")
+                    .compactMap { Int($0) }
+                return ports.isEmpty ? nil : (csrf, ports)
+            }
+    }
+
+    /// Ask every running language server, on each of its ports, until one returns a response
+    /// `accept` recognises. Returns the payload plus the endpoint it came from, since the credit
+    /// row is fetched from that same server.
+    ///
+    /// Several servers can run at once — Antigravity.app and Antigravity IDE.app both ship one and
+    /// report the *same* account quota — and a freshly started one answers
+    /// `"error getting token source"` while its sibling is serving fine. Trying only the first
+    /// process would drop the whole live source while a working server sat right next to it.
+    private func antigravityProbe(path: String,
+                                  accept: ([String: Any]) -> Bool) -> (json: [String: Any], csrf: String, ports: [Int])? {
+        let body = "{\"metadata\":{\"ideName\":\"antigravity\",\"extensionName\":\"antigravity\",\"locale\":\"en\",\"ideVersion\":\"unknown\"}}"
+        for (csrf, ports) in antigravityLanguageServerEndpoints() {
+            for p in ports {
+                let out = antigravityCurl(port: p, path: path, body: body, csrf: csrf)
+                guard let data = out.data(using: .utf8),
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      accept(json) else { continue }
+                return (json, csrf, ports)
+            }
         }
-        return (csrf, ports)
+        return nil
     }
 
     /// Call the grouped quota summary RPC the IDE's Model Quota page uses. Each group
     /// (Gemini, Claude+GPT) carries a weekly and a 5-hour bucket — flattened to one row each.
     private func fetchAntigravityQuotaSummary() -> ServiceStatus? {
-        guard let (csrf, ports) = antigravityLanguageServerEndpoint() else {
+        guard let hit = antigravityProbe(path: "RetrieveUserQuotaSummary", accept: { json in
+            let g = (json["response"] as? [String: Any])?["groups"] as? [[String: Any]]
+            return !(g?.isEmpty ?? true)
+        }) else {
             return nil
         }
-
-        let body = "{\"metadata\":{\"ideName\":\"antigravity\",\"extensionName\":\"antigravity\",\"locale\":\"en\",\"ideVersion\":\"unknown\"}}"
-        var groups: [[String: Any]]?
-        for p in ports {
-            let out = antigravityCurl(port: p, path: "RetrieveUserQuotaSummary", body: body, csrf: csrf)
-            if let data = out.data(using: .utf8),
-               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let response = json["response"] as? [String: Any],
-               let g = response["groups"] as? [[String: Any]], !g.isEmpty {
-                groups = g
-                break
-            }
-        }
-        guard let groups else {
+        let (csrf, ports) = (hit.csrf, hit.ports)
+        guard let response = hit.json["response"] as? [String: Any],
+              let groups = response["groups"] as? [[String: Any]] else {
             return nil
         }
 
@@ -236,22 +247,8 @@ extension LiveUsageDataSource {
     }
 
     private func fetchAntigravityLocalLanguageServer(models defaults: [String]) -> ServiceStatus? {
-        guard let (csrf, ports) = antigravityLanguageServerEndpoint() else {
-            return nil
-        }
-
-        let body = "{\"metadata\":{\"ideName\":\"antigravity\",\"extensionName\":\"antigravity\",\"locale\":\"en\",\"ideVersion\":\"unknown\"}}"
-        var payload: [String: Any]?
-        for p in ports {
-            let out = antigravityCurl(port: p, path: "GetUserStatus", body: body, csrf: csrf)
-            if let data = out.data(using: .utf8),
-               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               json["userStatus"] != nil {
-                payload = json
-                break
-            }
-        }
-        guard let payload else {
+        guard let payload = antigravityProbe(path: "GetUserStatus",
+                                             accept: { $0["userStatus"] != nil })?.json else {
             return nil
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [2.10] - 2026-08-16
+
+#### Fixed
+- Antigravity's quota could stop updating when more than one Antigravity language server was running — the desktop app and the IDE each start their own, and a server that has just launched answers with an auth error while its sibling is serving fine. Mimir asked only the first one it found and gave up if that one didn't answer. It now tries each running server until one responds, so the card keeps updating.
+
 ### [2.9] - 2026-08-14
 
 #### Added
@@ -400,6 +405,11 @@ Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
 
 ### [Yayımlanmadı]
+
+### [2.10] - 2026-08-16
+
+#### Düzeltildi
+- Birden fazla Antigravity dil sunucusu çalışırken Antigravity kotası güncellenmeyi bırakabiliyordu — masaüstü uygulaması ve IDE ayrı ayrı kendi sunucusunu başlatıyor, yeni başlamış olan bir kimlik doğrulama hatası döndürürken diğeri sorunsuz cevap verebiliyor. Mimir yalnızca bulduğu ilkine soruyor, o cevap vermeyince pes ediyordu. Artık cevap alana kadar çalışan tüm sunucuları sırayla deniyor; kart güncellenmeye devam ediyor.
 
 ### [2.9] - 2026-08-14
 


### PR DESCRIPTION
## Problem

`antigravityLanguageServerEndpoint()` returned only the **first** matching process:

```swift
guard let row = processRows.first else { return nil }
```

It looped over that process's ports, but never over the other processes. Both the primary quota source (`fetchAntigravityQuotaSummary` → `RetrieveUserQuotaSummary`) and the local-language-server fallback (`fetchAntigravityLocalLanguageServer` → `GetUserStatus`) go through it, so one unhealthy process took out both.

A machine really does run several. On the test machine, with the desktop app and the IDE both open:

```
pid 15570  Antigravity IDE.app   port 54298  ->  quota OK
pid 15643  Antigravity IDE.app   port 54336  ->  quota OK
pid 15691  Antigravity.app       port 54368  ->  quota OK
```

They report the **same account quota** — reset timestamps match to the second across processes. And a freshly launched server can answer:

```json
{"code":"internal","message":"internal: failed to get load code assist response: error getting token source: state sync..."}
```

which was observed live on a fourth process earlier in the session. When that process sorts first, the card silently falls back to the 6-hour Cockpit cache while a healthy server sits right next to it. No error surfaces; the quota just goes stale.

## Fix

Return every endpoint, probe them in order, stop at the first usable response. Both call sites were duplicating the same port loop, so they collapse into one `antigravityProbe(path:accept:)` helper — **the diff removes more than it adds** (47 insertions, 50 deletions).

## Verification

Live, against three running servers, with the first one frozen by `SIGSTOP` so it stayed in the process list and kept its port open but stopped answering — exactly the "first endpoint dead, healthy ones behind it" case:

| | snapshot written? |
|---|---|
| old code | no — gave up at the first endpoint |
| new code | yes — read the quota from the next server |

Then `SIGCONT`, rebuild, quota still reads normally. `swift build` clean, `swift test` 90 passed.

## What this is *not*

Issue #40 suggested Google had renamed `Antigravity.app` to `Gemini.app` (`com.google.GeminiMacOS`) and that the `grep antigravity` filter needed a `gemini.app` branch. Checked against all three apps installed side by side:

| App | Bundle ID | Version | `language_server` |
|---|---|---|---|
| Antigravity.app | `com.google.antigravity` | 2.8.1 | `Contents/Resources/bin/language_server` |
| Antigravity IDE.app | `com.google.antigravity-ide` | 2.5.5 | `.../extensions/antigravity/bin/language_server_macos_arm` |
| Gemini.app | `com.google.GeminiMacOS` | 1.94.11.734 | **none** |

No rename. Gemini.app ships no language server at all and is a separate product; Antigravity is still `com.google.antigravity` and on a *newer* version. The existing filter matches both Antigravity processes correctly. Adding a `gemini.app` branch would only risk matching unrelated processes, so the grep is left alone.

## Note

Targets 2.10, same as #42. Both add a `### [2.10]` block to `docs/CHANGELOG.md`, so whichever merges second will need a trivial conflict resolution there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)