### PR TITLE
fix(snapshot): persist the quota window's real length

### DIFF
--- a/Sources/Mimir/LiveUsageDataSource.swift
+++ b/Sources/Mimir/LiveUsageDataSource.swift
@@ -238,8 +238,12 @@ struct LiveUsageDataSource {
         let sessionReset = (root["sessionResetAt"] as? String).flatMap { parseISO8601($0) }
         let weeklyReset = (root["weeklyResetAt"] as? String).flatMap { parseISO8601($0) }
         // Absent in snapshots written before this key existed — nil then, and the callers fall back
-        // to the 7-day default exactly as they did before.
-        let weeklyWindow = (root["weeklyWindowSeconds"] as? NSNumber)?.doubleValue
+        // to the 7-day default exactly as they did before. Bounds-checked because the on-disk value
+        // is untrusted: a corrupt/hand-edited number outside (6h, 366d] would trap in the
+        // Double→Int of quotaWindowDays (e.g. 1e300) or hang rollForward's stepping loop (≤0).
+        let weeklyWindow = (root["weeklyWindowSeconds"] as? NSNumber)
+            .map(\.doubleValue)
+            .flatMap { $0.isFinite && $0 > 6 * 3600 && $0 <= 366 * 86_400 ? $0 : nil }
 
         // Live source unreachable long enough (>4.5 h — just under the 5-hour session window, beyond
         // which the last-known session reading is from a window that has already rotated, so it's

--- a/Sources/Mimir/LiveUsageDataSource.swift
+++ b/Sources/Mimir/LiveUsageDataSource.swift
@@ -150,6 +150,10 @@ struct LiveUsageDataSource {
         if let p = status.weeklyRemainingPercent { payload["weeklyRemainingPercent"] = p }
         if let d = status.sessionResetAt { payload["sessionResetAt"] = iso.string(from: d) }
         if let d = status.weeklyResetAt { payload["weeklyResetAt"] = iso.string(from: d) }
+        // Without the window's real length a restored snapshot falls back to "7 days", which both
+        // mislabels a longer window (ChatGPT Go's ~30-day one) and rolls a lapsed reset forward by
+        // the wrong step.
+        if let s = status.weeklyWindowSeconds { payload["weeklyWindowSeconds"] = s }
         if !status.models.isEmpty {
             payload["models"] = status.models.map { m -> [String: Any] in
                 var dict: [String: Any] = ["name": m.name, "remainingPercent": m.remainingPercent]
@@ -233,6 +237,9 @@ struct LiveUsageDataSource {
         }
         let sessionReset = (root["sessionResetAt"] as? String).flatMap { parseISO8601($0) }
         let weeklyReset = (root["weeklyResetAt"] as? String).flatMap { parseISO8601($0) }
+        // Absent in snapshots written before this key existed — nil then, and the callers fall back
+        // to the 7-day default exactly as they did before.
+        let weeklyWindow = (root["weeklyWindowSeconds"] as? NSNumber)?.doubleValue
 
         // Live source unreachable long enough (>4.5 h — just under the 5-hour session window, beyond
         // which the last-known session reading is from a window that has already rotated, so it's
@@ -254,6 +261,7 @@ struct LiveUsageDataSource {
                 sessionResetAt: sessionReset, weeklyResetAt: weeklyReset,
                 sessionRemainingPercent: root["sessionRemainingPercent"] as? Int,
                 weeklyRemainingPercent: root["weeklyRemainingPercent"] as? Int,
+                weeklyWindowSeconds: weeklyWindow,
                 models: allModels, isAvailable: false, statusNote: staleNote,
                 isStale: true, dataUnavailable: true)
         }
@@ -262,6 +270,7 @@ struct LiveUsageDataSource {
             name: service, iconName: iconName,
             sessionPct: root["sessionRemainingPercent"] as? Int, sessionReset: sessionReset,
             weeklyPct: root["weeklyRemainingPercent"] as? Int, weeklyReset: weeklyReset,
+            weeklyWindowSeconds: weeklyWindow,
             models: allModels, freshNote: freshNote, staleNote: staleNote)
     }
 
@@ -282,10 +291,14 @@ struct LiveUsageDataSource {
     func staleClassifiedCard(name: String, iconName: String,
                                      sessionPct: Int?, sessionReset: Date?,
                                      weeklyPct: Int?, weeklyReset: Date?,
+                                     weeklyWindowSeconds: TimeInterval? = nil,
                                      models: [ModelStatus],
                                      freshNote: String, staleNote: String) -> ServiceStatus? {
         guard sessionPct != nil || weeklyPct != nil || !models.isEmpty else { return nil }
         let now = Date()
+        // Roll a lapsed reset forward by the window's REAL length. Assuming 7 days would land a
+        // ~30-day window (ChatGPT Go) on a boundary it never has.
+        let weeklyPeriod = weeklyWindowSeconds ?? Self.weeklyResetPeriod
 
         // Advance a passed reset to the next future boundary so a refilled window still shows a live
         // countdown instead of a stale/blank one.
@@ -303,14 +316,14 @@ struct LiveUsageDataSource {
         }
 
         let s = window(sessionPct, sessionReset, Self.sessionResetPeriod)
-        let w = window(weeklyPct, weeklyReset, Self.weeklyResetPeriod)
+        let w = window(weeklyPct, weeklyReset, weeklyPeriod)
         // Keep every model row: an in-window one as-is, a lapsed (refilled) one at 100% with its weekly
         // reset rolled forward. Value rows (billing) carry no resetting percent — pass them through.
         let rows = models.map { m -> (row: ModelStatus, live: Bool) in
             if m.valueText != nil { return (m, true) }
             let live = m.resetAt.map { now < $0 } ?? true
             if live { return (m, true) }
-            return (ModelStatus(name: m.name, remainingPercent: 100, resetAt: rollForward(m.resetAt, Self.weeklyResetPeriod)), false)
+            return (ModelStatus(name: m.name, remainingPercent: 100, resetAt: rollForward(m.resetAt, weeklyPeriod)), false)
         }
 
         let anyLive = s.live || w.live || rows.contains { $0.live }
@@ -324,6 +337,7 @@ struct LiveUsageDataSource {
             name: name, iconName: iconName,
             sessionResetAt: s.reset, weeklyResetAt: w.reset,
             sessionRemainingPercent: s.pct, weeklyRemainingPercent: w.pct,
+            weeklyWindowSeconds: weeklyWindowSeconds,
             models: rows.map(\.row),
             isAvailable: true,
             statusNote: anyLive ? freshNote : staleNote,

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -372,6 +372,50 @@ final class UsageParsingTests: XCTestCase {
         XCTAssertNil(card?.weeklyWindowSeconds)
     }
 
+    /// The window length survives the real save→load JSON round trip (not just the in-memory path)
+    /// and drives the reset rollover on restore. A save/load key mismatch would fail here where the
+    /// direct staleClassifiedCard tests above would still pass. Uses a made-up service name so the
+    /// file never collides with a real provider's snapshot.
+    func testSnapshotRoundTripPreservesWindowLengthAndRollsReset() throws {
+        let month: TimeInterval = 30 * 86_400
+        let past = Date(timeIntervalSinceNow: -40 * 86_400)
+        let status = ServiceStatus(
+            name: "RoundTrip", iconName: "codex",
+            sessionResetAt: nil, weeklyResetAt: past,
+            weeklyRemainingPercent: 12, weeklyWindowSeconds: month,
+            models: [], isAvailable: true, statusNote: nil)
+        ds.saveSnapshot(status)
+        defer { try? FileManager.default.removeItem(at: ds.snapshotURL(for: "RoundTrip")) }
+
+        let card = try XCTUnwrap(ds.loadSnapshot(for: "RoundTrip", iconName: "codex"))
+        XCTAssertEqual(card.weeklyWindowSeconds, month)
+        // 40 days past + two 30-day steps = 20 days out — proof the persisted length, not the
+        // 7-day default, stepped the lapsed reset.
+        let rolled = try XCTUnwrap(card.weeklyResetAt)
+        XCTAssertEqual(rolled.timeIntervalSince(past), 60 * 86_400, accuracy: 60)
+    }
+
+    /// An absurd on-disk window length (corrupt or hand-edited snapshot) is dropped at load instead
+    /// of reaching quotaWindowDays' Double→Int conversion, where 1e300 would trap and crash the app
+    /// on every launch until the file is deleted.
+    func testSnapshotLoadDropsOutOfRangeWindowLength() throws {
+        let iso = ISO8601DateFormatter()
+        let past = iso.string(from: Date(timeIntervalSinceNow: -10 * 86_400))
+        let json = """
+        {"version":1,"savedAt":"\(iso.string(from: Date()))","weeklyRemainingPercent":30,\
+        "weeklyResetAt":"\(past)","weeklyWindowSeconds":1e300}
+        """
+        let url = ds.snapshotURL(for: "RoundTrip")
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try json.data(using: .utf8)!.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let card = try XCTUnwrap(ds.loadSnapshot(for: "RoundTrip", iconName: "codex"))
+        XCTAssertNil(card.weeklyWindowSeconds)          // out-of-range → dropped
+        XCTAssertNil(quotaWindowDays(card.weeklyWindowSeconds))   // and the badge stays off
+    }
+
     /// A card with even ONE refilled window is an estimate → `isStale`, so it's excluded from the reset
     /// notification path (which fires on `!isStale`). This stops the false "weekly quota refilled" spam
     /// when a stale card bounces its weekly to a refilled 100 while the session is still live.

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -340,6 +340,38 @@ final class UsageParsingTests: XCTestCase {
         XCTAssertGreaterThan(card!.models.first!.resetAt!, Date())
     }
 
+    /// A lapsed reset is rolled forward by the window's REAL length. With a ~30-day window (ChatGPT Go)
+    /// and a reset 40 days old, stepping by 30 days lands 20 days out; the old hardcoded 7-day step
+    /// would have landed within a week — a boundary that window never has.
+    func testStaleCardRollsResetForwardByRealWindowLength() {
+        let month: TimeInterval = 30 * 86_400
+        let past = Date(timeIntervalSinceNow: -40 * 86_400)
+        let card = ds.staleClassifiedCard(
+            name: "Codex", iconName: "codex",
+            sessionPct: nil, sessionReset: nil,
+            weeklyPct: 12, weeklyReset: past,
+            weeklyWindowSeconds: month,
+            models: [], freshNote: "fresh", staleNote: "stale")
+        let rolled = try! XCTUnwrap(card?.weeklyResetAt)
+        XCTAssertGreaterThan(rolled, Date())
+        // 40 days past + two 30-day steps = 20 days out, not the ~2 days a 7-day step would give.
+        XCTAssertEqual(rolled.timeIntervalSince(past), 60 * 86_400, accuracy: 60)
+        XCTAssertEqual(card?.weeklyWindowSeconds, month)            // survives into the restored card
+    }
+
+    /// No reported length → the 7-day default, exactly as before this field existed.
+    func testStaleCardFallsBackToSevenDaysWithoutWindowLength() {
+        let past = Date(timeIntervalSinceNow: -10 * 86_400)
+        let card = ds.staleClassifiedCard(
+            name: "Claude", iconName: "claude",
+            sessionPct: nil, sessionReset: nil,
+            weeklyPct: 30, weeklyReset: past,
+            models: [], freshNote: "fresh", staleNote: "stale")
+        let rolled = try! XCTUnwrap(card?.weeklyResetAt)
+        XCTAssertEqual(rolled.timeIntervalSince(past), 14 * 86_400, accuracy: 60)
+        XCTAssertNil(card?.weeklyWindowSeconds)
+    }
+
     /// A card with even ONE refilled window is an estimate → `isStale`, so it's excluded from the reset
     /// notification path (which fires on `!isStale`). This stops the false "weekly quota refilled" spam
     /// when a stale card bounces its weekly to a refilled 100 while the session is still live.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+#### Fixed
+- A quota card restored from its saved copy — after a restart, or while the live source is unreachable — lost track of how long its window was and fell back to assuming a week. On a monthly window that showed the wrong label and counted down to a reset date that window never has.
+
 ### [2.10] - 2026-08-16
 
 #### Fixed
@@ -406,6 +409,9 @@ Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
 
 ### [Yayımlanmadı]
+
+#### Düzeltildi
+- Kayıtlı kopyasından geri yüklenen bir kota kartı — yeniden başlatmadan sonra ya da canlı kaynağa ulaşılamazken — penceresinin ne kadar uzun olduğunu unutup bir hafta varsayıyordu. Aylık bir pencerede bu, yanlış etiket ve o pencerenin hiç görmediği bir sıfırlanma tarihine geri sayım demekti.
 
 ### [2.10] - 2026-08-16
 


### PR DESCRIPTION
## Problem

Follow-up to #39 (2.8), which taught the UI to label a quota window by its real length instead of assuming 7 days. The snapshot path was missed.

`saveSnapshot` writes the weekly percent and reset but not `weeklyWindowSeconds`. So when a card is restored from a snapshot — app restart, live source unreachable, fetch cooldown after a 429 — the length comes back `nil` and two things silently revert to the old assumption:

1. **The badge.** `sessionHeroes` falls back to `?? 7 * 24 * 3600`, so a ~30-day ChatGPT Go window is relabelled **"7d"** — exactly the bug #39 fixed, re-entering through the restore path.
2. **The reset roll-forward.** `staleClassifiedCard` advanced a lapsed reset with the hardcoded `Self.weeklyResetPeriod` (7 days). On a 30-day window that lands on a boundary the window never has, so the countdown is wrong until the next live fetch.

Invisible on Plus/Pro, where the window really is 7 days and both paths agree.

## Fix

Write the length into the snapshot, read it back, and pass it into `staleClassifiedCard` so the roll-forward steps by the real period. Older snapshots have no such key, decode to `nil`, and keep the 7-day default — no migration needed.

## Tests

Two, and the first one earned its keep: it caught that `staleClassifiedCard` was rolling the reset correctly but dropping `weeklyWindowSeconds` from the card it returned, so the badge would still have been wrong.

- 30-day window, reset 40 days old → rolls two 30-day steps to 60 days past the original, and the restored card still carries the length
- no reported length → 7-day steps, `weeklyWindowSeconds` stays nil

`swift test` 92 passed (2 new). `BUILD_ONLY=1 ./script/release.sh 0.0` builds app + widget.

## Scope

Nothing outside the snapshot path changes. Claude and Antigravity report no window length, so they take the `nil` branch and behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)