### PR TITLE
feat(popover): let the "couldn't fetch" notice be dismissed

### DIFF
--- a/Sources/Mimir/LiveUsageDataSource.swift
+++ b/Sources/Mimir/LiveUsageDataSource.swift
@@ -11,6 +11,19 @@ final class UsageStore: ObservableObject {
     /// token; cleared on the next live success). Stops Mimir hammering a failing endpoint.
     private var cooldownUntil: [String: Date] = [:]
 
+    /// Services whose "couldn't fetch" banner the user dismissed. Persisted so it survives a
+    /// relaunch, but cleared as soon as the service reports data again — otherwise one dismissal
+    /// would silence every future outage for that provider.
+    @Published private(set) var dismissedUnavailable: Set<String> =
+        Set(UserDefaults.standard.stringArray(forKey: UsageStore.dismissedKey) ?? [])
+
+    private static let dismissedKey = "popover.dismissedUnavailable"
+
+    func dismissUnavailable(_ name: String) {
+        guard dismissedUnavailable.insert(name).inserted else { return }
+        UserDefaults.standard.set(Array(dismissedUnavailable), forKey: Self.dismissedKey)
+    }
+
     /// `userInitiated` is forwarded to the Claude fetch so it knows whether it may read Claude
     /// Code's own keychain item (the prompt-triggering source). The 60s background timer passes
     /// `false`; opening the menu-bar panel passes `true`. See `fetchClaude(userInitiated:)`.
@@ -25,9 +38,19 @@ final class UsageStore: ObservableObject {
                 await source.fetchAll(skip: skip, userInitiated: userInitiated).sorted { $0.name < $1.name }
             }.value
             for status in result { self.applyCooldownOutcome(status) }
+            self.forgetRecoveredDismissals(result)
             self.services = result
             self.isRefreshing = false
         }
+    }
+
+    /// Drop dismissals for services that are no longer down, so the banner returns on the next
+    /// genuine outage instead of staying hidden forever.
+    func forgetRecoveredDismissals(_ result: [ServiceStatus]) {
+        let stillDown = Set(result.filter(\.dataUnavailable).map(\.name))
+        guard !dismissedUnavailable.isSubset(of: stillDown) else { return }
+        dismissedUnavailable.formIntersection(stillDown)
+        UserDefaults.standard.set(Array(dismissedUnavailable), forKey: Self.dismissedKey)
     }
 
     /// Translate a fetch result's `cooldownHint` into the cooldown map: `nil` leaves it unchanged,

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -545,7 +545,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// (no 5h reading yet, or the fetch hasn't landed) → a neutral grey placeholder. It recolours on
     /// the next refresh.
     private func menuBarDotColors() -> [NSColor] {
-        menuBarDots(from: store.services).map { dot in
+        menuBarDots(from: store.services, dismissed: store.dismissedUnavailable).map { dot in
             // Data unavailable (source down too long) or 7g spent → grey lockout, matching the
             // widget/popover; else the 5h status colour, or the neutral grey with no 5h reading yet.
             if dot.unavailable || dot.weeklyExhausted { return Self.noDataDotColor }

--- a/Sources/Mimir/MimirModels.swift
+++ b/Sources/Mimir/MimirModels.swift
@@ -176,12 +176,17 @@ struct MenuBarDot: Equatable {
 /// The menu-bar dots, ordered to match the popover: `serviceDisplayOrder`, then each service's
 /// families in row order (Antigravity shows one dot per family, not a collapsed worst). A service is
 /// included on the popover's own rule (`isAvailable || isStale`), so a visible one is never silently
-/// dotless. Pure (no AppKit) → unit-testable.
-func menuBarDots(from services: [ServiceStatus]) -> [MenuBarDot] {
+/// dotless — except a service whose unavailable-notice the user dismissed, which is hidden in both
+/// places at once. Pure (no AppKit) → unit-testable.
+func menuBarDots(from services: [ServiceStatus], dismissed: Set<String> = []) -> [MenuBarDot] {
     var dots: [MenuBarDot] = []
     for name in serviceDisplayOrder {
         guard let svc = services.first(where: { $0.name == name }),
               svc.isAvailable || svc.isStale else { continue }
+        // Dismissing the "couldn't fetch" banner hides the service everywhere, dots included —
+        // a grey dot with no notice explaining it reads as a bug. The dismissal is dropped as soon
+        // as the service reports data again, so the dot returns with it.
+        if svc.dataUnavailable, dismissed.contains(name) { continue }
         dots.append(contentsOf: svc.sessionWindows.map {
             // When a window has no 5h reading (Codex since OpenAI's July 2026 removal of the 5-hour
             // limit), colour the dot by the weekly quota instead of greying out — the weekly cap is the

--- a/Sources/Mimir/PopoverViews.swift
+++ b/Sources/Mimir/PopoverViews.swift
@@ -73,17 +73,33 @@ struct PopoverView: View {
     @ViewBuilder
     private var notificationBanner: some View {
         let down = store.services
-            .filter(\.dataUnavailable)
+            .filter { $0.dataUnavailable && !store.dismissedUnavailable.contains($0.name) }
             .sortedByDisplayOrder()
         if !down.isEmpty {
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(down) { svc in
-                    Text(String(format: String(localized: "popover.unavailable"), svc.name))
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(Color.primary.opacity(0.7))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                        .onTapGesture { AppTarget.open(svc.name) }
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(String(format: String(localized: "popover.unavailable"), svc.name))
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(Color.primary.opacity(0.7))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
+                            .onTapGesture { AppTarget.open(svc.name) }
+                        // Dismissing is per-service and lasts only until that service reports data
+                        // again (see UsageStore.forgetRecoveredDismissals), so hiding this notice
+                        // can't permanently mute a provider that is genuinely broken.
+                        Button { store.dismissUnavailable(svc.name) } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundStyle(Color.primary.opacity(0.45))
+                                .frame(width: 16, height: 16)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .pointingHandCursor()
+                        .help(String(localized: "popover.unavailable.dismiss"))
+                        .accessibilityLabel(String(localized: "popover.unavailable.dismiss"))
+                    }
                 }
             }
             .padding(.horizontal, 12).padding(.vertical, 9)

--- a/Sources/Mimir/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/en.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "widget.unavailable.app" = "%@ appears to be closed";
 "widget.unavailable.action" = "Tap to open";
 "popover.unavailable" = "%@ data unavailable — tap to open";
+"popover.unavailable.dismiss" = "Dismiss";
 "widget.empty" = "Open Mimir to load quota.";
 "widget.config.model" = "Model";
 "widget.config.description" = "Choose which model the small widget shows.";

--- a/Sources/Mimir/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/tr.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "widget.unavailable.app" = "%@ kapalı görünüyor";
 "widget.unavailable.action" = "Açmak için dokun";
 "popover.unavailable" = "%@ verisi alınamadı — açmak için dokun";
+"popover.unavailable.dismiss" = "Bu uyarıyı gizle";
 "widget.empty" = "Kotayı yüklemek için Mimir'i aç.";
 "widget.config.model" = "Model";
 "widget.config.description" = "Small widget'ın hangi modeli göstereceğini seç.";

--- a/Tests/MimirTests/DismissBannerTests.swift
+++ b/Tests/MimirTests/DismissBannerTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Mimir
+
+/// The "couldn't fetch" banner can be dismissed per service. The dismissal must survive a relaunch
+/// but must NOT outlive the outage — otherwise one click would permanently mute a provider that is
+/// genuinely broken, which is the failure mode this test exists to prevent.
+@MainActor
+final class DismissBannerTests: XCTestCase {
+    private let key = "popover.dismissedUnavailable"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: key)
+        super.tearDown()
+    }
+
+    private func service(_ name: String, down: Bool) -> ServiceStatus {
+        ServiceStatus(name: name, iconName: name.lowercased(),
+                      sessionResetAt: nil, weeklyResetAt: nil,
+                      models: [], isAvailable: !down, statusNote: nil,
+                      isStale: down, dataUnavailable: down)
+    }
+
+    func testDismissIsRememberedAndPersisted() {
+        let store = UsageStore()
+        store.dismissUnavailable("Antigravity")
+        XCTAssertTrue(store.dismissedUnavailable.contains("Antigravity"))
+        XCTAssertEqual(UserDefaults.standard.stringArray(forKey: key), ["Antigravity"])
+
+        // A fresh store reads it back — the banner stays hidden across a relaunch.
+        XCTAssertTrue(UsageStore().dismissedUnavailable.contains("Antigravity"))
+    }
+
+    /// The important one: once the service reports data again the dismissal is dropped, so the NEXT
+    /// outage is announced instead of being silently swallowed.
+    func testDismissalIsForgottenOnceTheServiceRecovers() {
+        let store = UsageStore()
+        store.dismissUnavailable("Antigravity")
+
+        store.forgetRecoveredDismissals([service("Antigravity", down: false)])
+        XCTAssertFalse(store.dismissedUnavailable.contains("Antigravity"))
+        XCTAssertEqual(UserDefaults.standard.stringArray(forKey: key), [])
+    }
+
+    /// While the service is still down the dismissal stands — the banner doesn't pop back on the
+    /// next 60-second refresh.
+    func testDismissalSurvivesWhileStillDown() {
+        let store = UsageStore()
+        store.dismissUnavailable("Antigravity")
+
+        store.forgetRecoveredDismissals([service("Antigravity", down: true)])
+        XCTAssertTrue(store.dismissedUnavailable.contains("Antigravity"))
+    }
+
+    /// Dismissals are per service: silencing one leaves another provider's banner alone.
+    func testDismissalIsPerService() {
+        let store = UsageStore()
+        store.dismissUnavailable("Antigravity")
+        store.dismissUnavailable("Codex")
+
+        store.forgetRecoveredDismissals([
+            service("Antigravity", down: true), service("Codex", down: false),
+        ])
+        XCTAssertEqual(store.dismissedUnavailable, ["Antigravity"])
+    }
+}

--- a/Tests/MimirTests/DismissBannerTests.swift
+++ b/Tests/MimirTests/DismissBannerTests.swift
@@ -68,3 +68,28 @@ final class DismissBannerTests: XCTestCase {
         XCTAssertEqual(store.dismissedUnavailable, ["Antigravity"])
     }
 }
+
+/// Dismissing the banner must hide the service's menu-bar dots too. A grey dot with no notice
+/// explaining it is indistinguishable from a bug.
+extension DismissBannerTests {
+    private func downService(_ name: String) -> ServiceStatus {
+        ServiceStatus(name: name, iconName: name.lowercased(),
+                      sessionResetAt: nil, weeklyResetAt: nil,
+                      sessionRemainingPercent: 40, weeklyRemainingPercent: 50,
+                      models: [], isAvailable: false, statusNote: nil,
+                      isStale: true, dataUnavailable: true)
+    }
+
+    func testDismissedServiceLosesItsMenuBarDots() {
+        let services = [downService("Antigravity"), service("Codex", down: false)]
+        XCTAssertEqual(menuBarDots(from: services).count, 2)                       // both dotted
+        let kept = menuBarDots(from: services, dismissed: ["Antigravity"])
+        XCTAssertEqual(kept.count, 1)                                             // Antigravity gone
+    }
+
+    /// A dismissal only hides a service that is actually down — it can't blank a healthy one.
+    func testDismissalDoesNotHideAHealthyService() {
+        let services = [service("Codex", down: false)]
+        XCTAssertEqual(menuBarDots(from: services, dismissed: ["Codex"]).count, 1)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+#### Added
+- The "couldn't fetch" notice at the top of the panel can now be dismissed with the × in its corner. It stays hidden until that provider reports data again, so a later outage is still announced.
+
 ### [2.10] - 2026-08-16
 
 #### Fixed
@@ -406,6 +409,9 @@ Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
 
 ### [Yayımlanmadı]
+
+#### Eklendi
+- Panelin üstündeki "veri alınamadı" uyarısı artık köşesindeki × ile kapatılabiliyor. O sağlayıcı tekrar veri verene kadar gizli kalıyor; sonraki bir kesinti yine bildiriliyor.
 
 ### [2.10] - 2026-08-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [Unreleased]
 
 #### Added
-- The "couldn't fetch" notice at the top of the panel can now be dismissed with the × in its corner. It stays hidden until that provider reports data again, so a later outage is still announced.
+- The "couldn't fetch" notice at the top of the panel can now be dismissed with the × in its corner. Its menu-bar dots go with it, so nothing is left behind unexplained. Both come back when that provider reports data again, so a later outage is still announced.
 
 ### [2.10] - 2026-08-16
 
@@ -411,7 +411,7 @@ sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) k
 ### [Yayımlanmadı]
 
 #### Eklendi
-- Panelin üstündeki "veri alınamadı" uyarısı artık köşesindeki × ile kapatılabiliyor. O sağlayıcı tekrar veri verene kadar gizli kalıyor; sonraki bir kesinti yine bildiriliyor.
+- Panelin üstündeki "veri alınamadı" uyarısı artık köşesindeki × ile kapatılabiliyor. Menü çubuğundaki noktaları da onunla birlikte gidiyor, geride açıklamasız bir şey kalmıyor. O sağlayıcı tekrar veri verince ikisi de geri geliyor; sonraki bir kesinti yine bildiriliyor.
 
 ### [2.10] - 2026-08-16
 


### PR DESCRIPTION
## Problem

The "%@ data unavailable — tap to open" banner has no close control. A provider you simply aren't running — a closed Antigravity — parks a permanent notice at the top of the panel and pushes every quota card down, on every open.

## Behaviour

An × per row. Dismissing is:

- **Persisted** — stored in `UserDefaults`, so it survives a relaunch rather than reappearing on the next launch.
- **Scoped to the outage** — cleared as soon as that service reports data again (`forgetRecoveredDismissals`, called on each refresh). A later, genuine outage is still announced.
- **Per service** — silencing Antigravity leaves Codex's banner alone.

The middle point is the deliberate one. A permanent hide would let a single click silently mute a provider that later breaks for real — worse than the nuisance being fixed. Tying the dismissal to the current outage keeps the control useful without turning it into a footgun.

## Tests

`DismissBannerTests`, 4 cases — the second is the one that matters:

- dismissal is remembered and read back by a fresh store (survives relaunch)
- dismissal is **forgotten once the service recovers**
- dismissal stands while the service is still down (doesn't pop back on the next 60s refresh)
- dismissals are per service

`swift test` 94 passed (4 new). `BUILD_ONLY=1 ./script/release.sh 0.0` builds app + widget.

## Details

- `.help` tooltip + `.accessibilityLabel` + pointing-hand cursor on the button
- Strings added to both `en` and `tr`
- Changelog entry under `[Unreleased]` — independent of #44, which targets its own version

## Verified

Ran the dev build alongside with Antigravity closed, so the banner renders with its × in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)