### PR TITLE
docs: cover the dismissible notice and multi-server Antigravity reads

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ Mimir's entire UI lives in the menu bar: a small **Mimir glyph** and a vertical 
 
 **The popover** — click the glyph to open it. Each service is a card with its name and brand icon, the session (5-hour) quota shown prominently with percentage and countdown, a weekly summary row, per-model quota or credit rows, an (i) info icon, and a status note (e.g. *"token expired — open Claude Code"*). When a service has no session window, the weekly reading is promoted into that spot instead. Reset times use short units — e.g. `2h 15m`.
 
-**Refreshing & stale state** — Mimir refreshes every minute and on each popover open; if a service hits a rate limit (HTTP 429) it backs off and shows the last-known data. When a live source disappears (e.g. the Antigravity IDE closes), the card is shown **dimmed** with the last snapshot instead of vanishing.
+**Refreshing & stale state** — Mimir refreshes every minute and on each popover open; if a service hits a rate limit (HTTP 429) it backs off and shows the last-known data. When a live source disappears (e.g. the Antigravity IDE closes), the card is shown **dimmed** with the last snapshot instead of vanishing. If it stays unreachable long enough, a notice appears at the top of the popover; dismiss it with the **×** in its corner and that service's dots leave the menu bar with it. Both return once the service reports data again, so a later outage is still announced.
 
 ### Documentation
 
@@ -167,7 +167,7 @@ Mimir'in tüm arayüzü menü çubuğunda yaşar: küçük bir **Mimir simgesi**
 
 **Açılır pencere (popover)** — simgeye tıklayınca açılır. Her servis bir karttır: ad ve marka ikonu, belirgin gösterilen seans (5 saatlik) kotası (yüzde + geri sayım), haftalık özet satırı, per-model kota veya kredi satırları, (i) bilgi simgesi ve bir durum notu (örn. *"token süresi doldu — Claude Code'u aç"*). Bir servisin seans penceresi yoksa haftalık okuma o alana terfi eder. Yenilenme süreleri kısa birimlerle: örn. `2s 15d`.
 
-**Yenileme & eski veri** — Mimir dakikada bir ve her popover açılışında yeniler; bir servis hız sınırına (HTTP 429) takılırsa geri çekilir ve son bilinen veriyi gösterir. Canlı kaynak kaybolduğunda (ör. Antigravity IDE'si kapanınca) kart yok olmaz, **soluk** (dimmed) hâlde son anlık görüntüyle kalır.
+**Yenileme & eski veri** — Mimir dakikada bir ve her popover açılışında yeniler; bir servis hız sınırına (HTTP 429) takılırsa geri çekilir ve son bilinen veriyi gösterir. Canlı kaynak kaybolduğunda (ör. Antigravity IDE'si kapanınca) kart yok olmaz, **soluk** (dimmed) hâlde son anlık görüntüyle kalır. Yeterince uzun süre ulaşılamazsa popover'ın üstünde bir uyarı belirir; köşesindeki **×** ile kapattığınızda o servisin noktaları da menü çubuğundan gider. Servis tekrar veri verince ikisi de geri gelir, böylece sonraki bir kesinti yine bildirilir.
 
 ### Dokümantasyon
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -79,7 +79,7 @@ Mimir shows group-based quotas for **Antigravity**. Antigravity no longer manage
 1. **Group quota summary** — the grouped weekly + 5-hour summary that backs the IDE's "Model Quota" page (primary live source).
 2. **Cloud Code authorized API** — a `fetchAvailableModels` call with your Cockpit account's token.
 3. **Cockpit cache** — the last authorized data stored locally.
-4. **Local language server** data.
+4. **Local language server** data. Several can be running at once — the desktop app and the IDE each start their own, and both report the same account quota — so Mimir asks each in turn until one answers. A server that has just launched can reply with an auth error while its sibling serves fine, and stopping at the first one would drop the whole source.
 5. **Last snapshot** — when the IDE/Cockpit is closed, valid until its reset time passes.
 
 **The menu bar dot.** Since Antigravity has **two session groups** (Gemini, Claude/GPT), the single Antigravity dot shows the color of the **most constrained** group. When the IDE or Cockpit is closed, Mimir shows the **last snapshot**; if there is no account info at all, the card shows **open Antigravity or Cockpit**.
@@ -167,7 +167,7 @@ Mimir, **Antigravity** için grup bazlı kotaları gösterir. Antigravity kotay�
 1. **Grup kota özeti** — IDE'nin "Model Quota" sayfasını besleyen, gruplanmış haftalık + 5 saatlik özet (birincil canlı kaynak).
 2. **Cloud Code yetkili API'si** — Cockpit hesabınızın token'ıyla `fetchAvailableModels` çağrısı.
 3. **Cockpit önbelleği** — yerel olarak saklanan son yetkili veri.
-4. **Yerel dil sunucusu** (language server) verisi.
+4. **Yerel dil sunucusu** (language server) verisi. Aynı anda birden fazlası çalışıyor olabilir — masaüstü uygulaması ve IDE ayrı ayrı kendi sunucusunu başlatır, ikisi de aynı hesap kotasını bildirir — bu yüzden Mimir cevap alana kadar hepsini sırayla dener. Yeni başlamış bir sunucu kimlik doğrulama hatası döndürürken diğeri sorunsuz cevap verebilir; ilkinde durmak kaynağın tamamını düşürürdü.
 5. **Son anlık görüntü** (snapshot) — IDE/Cockpit kapalıysa, sıfırlanma zamanı geçene kadar geçerli.
 
 **Menü çubuğundaki nokta.** Antigravity'nin **iki seans grubu** olduğundan (Gemini, Claude/GPT), tek Antigravity noktası **en kısıtlı** grubun rengini gösterir. IDE veya Cockpit kapalıyken Mimir **son anlık görüntüyü** gösterir; hiç hesap bilgisi yoksa kart **Antigravity veya Cockpit'i aç** notunu verir.


### PR DESCRIPTION
## Why

Audited the docs against what shipped in this cycle. Two user-visible behaviours had no documentation; everything else already reads correctly.

## Changes

**`docs/README.md` — "Reading the menu bar"**

The "Refreshing & stale state" paragraph explained the dimmed-card fallback but stopped there. It now also covers the notice that appears when a source stays unreachable, the **×** that dismisses it, the fact that the service's menu-bar dots go with it, and that both return once data comes back.

**`docs/SERVICES.md` — Antigravity data sources**

Step 4 read "**Local language server** data", implying one. Several run at once — the desktop app and the IDE each start their own and both report the same account quota — and Mimir now probes each in turn (#43). Worth documenting: it's exactly the detail someone needs when working out why the Antigravity card did or didn't refresh.

Both edits in English and Turkish.

## Checked and left alone

- `docs/PRIVACY.md` — the TelemetryDeck row describes the signals, not the app id, so the #42 fix doesn't change it. Still accurate.
- `docs/INSTALLATION.md`, `CLAUDE.md` — untouched by any of this.
- The snapshot window-length fix (#44) is internal; `SERVICES.md` already states the badge comes from the window's real length, which now holds on the restore path too.

Docs only — no code, no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)