### PR TITLE
docs: cut 2.11

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [2.11] - 2026-08-24
+
 #### Added
 - The "couldn't fetch" notice at the top of the panel can now be dismissed with the × in its corner. Its menu-bar dots go with it, so nothing is left behind unexplained. Both come back when that provider reports data again, so a later outage is still announced.
 
@@ -412,6 +414,8 @@ Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
 
 ### [Yayımlanmadı]
+
+### [2.11] - 2026-08-24
 
 #### Eklendi
 - Panelin üstündeki "veri alınamadı" uyarısı artık köşesindeki × ile kapatılabiliyor. Menü çubuğundaki noktaları da onunla birlikte gidiyor, geride açıklamasız bir şey kalmıyor. O sağlayıcı tekrar veri verince ikisi de geri geliyor; sonraki bir kesinti yine bildiriliyor.


### PR DESCRIPTION
Promotes the two `[Unreleased]` entries to `### [2.11] - 2026-08-24` in both languages, ahead of tagging.

Contents:
- **Added** — the dismissible "couldn't fetch" notice, which also hides that service's menu-bar dots (#45)
- **Fixed** — snapshots keep the quota window's real length, so a restored card no longer relabels a monthly window as weekly or counts down to the wrong reset (#44)

`build_number.sh 2.11` → `2011000`, above 2.10's `2010000`. Release-note extraction verified with the workflow's own awk: both EN and TR resolve to 2 entries each. `swift test` 100 passed; app + widget build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)