### PR TITLE
refactor(telemetry): report the active provider as one dimension, not three flags

### DIFF
--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -389,7 +389,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         refreshCount += 1
         guard refreshCount >= 3 else { return }
         sentProviderSignal = true
-        Telemetry.signal("provider.active", parameters: Telemetry.providerParameters(from: services))
+        for name in Telemetry.activeProviderNames(from: services) {
+            Telemetry.signal("provider.active", parameters: ["service": name])
+        }
     }
 
     @objc private func togglePopover(_ sender: Any?) {

--- a/Sources/Mimir/Telemetry.swift
+++ b/Sources/Mimir/Telemetry.swift
@@ -24,13 +24,14 @@ enum Telemetry {
     /// The single gate every transmission passes through. Pure → unit-tested.
     static func shouldSend(isDev: Bool, enabled: Bool) -> Bool { !isDev && enabled }
 
-    /// Which providers are in use (available or showing stale data) — boolean only, never a value.
-    static func providerParameters(from services: [ServiceStatus]) -> [String: String] {
-        func active(_ name: String) -> String {
-            (services.first { $0.name == name }.map { $0.isAvailable || $0.isStale } ?? false)
-                ? "true" : "false"
-        }
-        return ["claude": active("Claude"), "codex": active("Codex"), "antigravity": active("Antigravity")]
+    /// The providers in use (available, or showing stale data) — names only, never a value.
+    ///
+    /// One `provider.active` signal is sent per name rather than a single signal carrying a flag
+    /// per provider, so `service` is one dimension the dashboard can slice into a share chart. A
+    /// provider added later becomes another value of that dimension: neither this function nor any
+    /// saved query has to change.
+    static func activeProviderNames(from services: [ServiceStatus]) -> [String] {
+        services.filter { $0.isAvailable || $0.isStale }.map(\.name)
     }
 
     /// Count of placed widgets per supported family (from WidgetCenter family raw names).

--- a/Tests/MimirTests/TelemetryTests.swift
+++ b/Tests/MimirTests/TelemetryTests.swift
@@ -12,7 +12,7 @@ final class TelemetryTests: XCTestCase {
         XCTAssertFalse(Telemetry.shouldSend(isDev: true, enabled: false))
     }
 
-    func testProviderParametersAreCategoricalOnly() {
+    func testActiveProviderNamesCoverInUseProvidersOnly() {
         let svcs = [
             ServiceStatus(name: "Claude", iconName: "claude", sessionResetAt: nil, weeklyResetAt: nil,
                           sessionRemainingPercent: 9, weeklyRemainingPercent: 11, models: [],
@@ -22,13 +22,12 @@ final class TelemetryTests: XCTestCase {
             ServiceStatus(name: "Antigravity", iconName: "antigravity", sessionResetAt: nil,
                           weeklyResetAt: nil, models: [], isAvailable: false, statusNote: nil),
         ]
-        let p = Telemetry.providerParameters(from: svcs)
-        XCTAssertEqual(p["claude"], "true")
-        XCTAssertEqual(p["codex"], "true")          // stale still counts as in-use
-        XCTAssertEqual(p["antigravity"], "false")
+        let names = Telemetry.activeProviderNames(from: svcs)
+        XCTAssertEqual(names, ["Claude", "Codex"])  // stale still counts as in-use
+        XCTAssertFalse(names.contains("Antigravity"))
         // No quota value may leak into the payload.
-        XCTAssertFalse(p.values.contains("9"))
-        XCTAssertFalse(p.values.contains("11"))
+        XCTAssertFalse(names.contains("9"))
+        XCTAssertFalse(names.contains("11"))
     }
 
     func testWidgetParametersCountFamilies() {

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -38,7 +38,7 @@ Two services do receive data, and neither gets anything about your usage:
 | Service | What it receives | Control |
 |---|---|---|
 | **Sentry** | Crash and error reports — technical app health only | Always on in released builds |
-| **TelemetryDeck** | Anonymous, categorical signals: which providers are in use (a yes/no, never a value) and how many widgets are placed | Opt-out from the popover menu |
+| **TelemetryDeck** | Anonymous, categorical signals: which providers are in use (the provider name, never a value) and how many widgets are placed | Opt-out from the popover menu |
 
 No quota percentages, reset times, credit balances, account ids or tokens are ever sent to either. Development builds send nothing at all.
 
@@ -92,7 +92,7 @@ Bu istekler, aracın kendisinin yapacağı isteklerle aynı niteliktedir. **Mimi
 | Servis | Ne alır | Denetim |
 |---|---|---|
 | **Sentry** | Çökme ve hata raporları — yalnızca uygulamanın teknik sağlığı | Yayınlanan sürümlerde her zaman açık |
-| **TelemetryDeck** | Anonim, kategorik sinyaller: hangi sağlayıcıların kullanıldığı (değer değil, yalnızca var/yok) ve kaç widget eklendiği | Popover menüsünden kapatılabilir |
+| **TelemetryDeck** | Anonim, kategorik sinyaller: hangi sağlayıcıların kullanıldığı (yalnızca sağlayıcının adı, hiçbir değer değil) ve kaç widget eklendiği | Popover menüsünden kapatılabilir |
 
 İkisine de kota yüzdesi, sıfırlanma zamanı, kredi bakiyesi, hesap kimliği veya token gönderilmez. Geliştirme sürümleri hiçbir şey göndermez.
 


### PR DESCRIPTION
## Problem

`provider.active` sent one boolean per provider — `claude`, `codex`, `antigravity`. That makes "which provider is in use" three columns instead of one dimension, so no chart can slice it as a share: a donut needs a single dimension whose values are the slices, and there wasn't one. Building the same view meant a timeseries with one filtered aggregator per provider, which renders as lines, not shares.

It also doesn't scale. Adding Cursor or Copilot ([MIL-277](https://linear.app/milowda/issue/MIL-277/cursor-kullanim-ve-harcama-takibi), [MIL-278](https://linear.app/milowda/issue/MIL-278/github-copilot-kota-takibi)) would have meant a new parameter here plus an edit to every saved query on the dashboard.

## Change

Send one `provider.active` signal per active provider, carrying its name in `service`:

```swift
for name in Telemetry.activeProviderNames(from: services) {
    Telemetry.signal("provider.active", parameters: ["service": name])
}
```

`providerParameters` becomes `activeProviderNames` — still pure, still unit-tested. `service` is now a single dimension, so the dashboard reads it directly, and a provider added later becomes another value of it with no query change.

## Privacy

Unchanged in substance: categorical only, the provider's name, never a quota percentage, reset time, credit, or account id — and behind the same opt-out gate. `docs/PRIVACY.md` described the payload as "a yes/no", which this makes inaccurate, so both the English and Turkish tables now say the provider name.

## Cost

Comparability with the existing `provider.active` history breaks at this release. That history is roughly 50 users across two months, split over the two TelemetryDeck apps, so the loss is small.

## Verification

- `swift test` — 100 passed
- The dashboard query this enables, verified against live data in the equivalent `notification.sent` shape (Codex 12 / Claude 11 / Antigravity 7 users, 30 days):

```json
{"queryType":"topN","granularity":"all","dimension":{"type":"default","dimension":"service","outputName":"Servis"},"threshold":10,"metric":{"type":"numeric","metric":"Kullanıcı"},"filter":{"type":"selector","dimension":"type","value":"provider.active"},"aggregations":[{"type":"thetaSketch","fieldName":"clientUser","name":"Kullanıcı"}]}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)