### PR TITLE
fix(claude): don't let a previous run's cache stand in for a live reading

### DIFF
--- a/Sources/Mimir/ClaudeDesktopSession.swift
+++ b/Sources/Mimir/ClaudeDesktopSession.swift
@@ -50,6 +50,8 @@ extension LiveUsageDataSource {
                 return nil
             }
 
+            // Before trusting anything cached, make sure it belongs to this account.
+            noteClaudeAccount(uuid)
             writeClaudeUsageCache(usageData)
             let status = buildClaudeStatus(from: root, note: "claude.ai desktop")
             saveSnapshot(status)

--- a/Sources/Mimir/ClaudeProvider.swift
+++ b/Sources/Mimir/ClaudeProvider.swift
@@ -9,7 +9,7 @@ extension LiveUsageDataSource {
     /// and stays on prompt-free sources (usage cache, the on-disk credential file, Mimir's own token
     /// cache); only a real user action — opening Mimir — passes `true` and may read that item.
     func fetchClaude(userInitiated: Bool) async -> ServiceStatus {
-        if let cached = readClaudeUsageCache(maxAge: 5 * 60) {
+        if let cached = readClaudeUsageCache(maxAge: 5 * 60, writtenThisSession: true) {
             return buildClaudeStatus(from: cached, note: "oauth usage cache").withCooldownHint(0)
         }
 
@@ -421,14 +421,65 @@ extension LiveUsageDataSource {
         return parseClaudeToken(raw)
     }
 
-    private func readClaudeUsageCache(maxAge: TimeInterval) -> [String: Any]? {
+    /// When this process started. A cache entry older than this was written by a previous run —
+    /// see `claudeCacheCountsAsFresh`.
+    private static let launchedAt = Date()
+
+    /// Is a cache entry fresh enough to skip a live fetch?
+    ///
+    /// Age alone isn't the whole rule. An entry written by an *earlier* run still loads instantly
+    /// (that's what keeps the card from flashing placeholders at launch), but it must never let the
+    /// app skip its first refresh: right after an update the user would otherwise stare at the
+    /// previous version's numbers until the interval lapsed. `writtenThisSession` marks the callers
+    /// that decide whether to fetch; the deep fallbacks pass false and keep trusting age alone.
+    ///
+    /// Pure so the rule can be unit-tested without touching the filesystem.
+    static func claudeCacheCountsAsFresh(
+        modifiedAt: Date, now: Date, maxAge: TimeInterval,
+        launchedAt: Date, writtenThisSession: Bool
+    ) -> Bool {
+        guard now.timeIntervalSince(modifiedAt) <= maxAge else { return false }
+        return writtenThisSession ? modifiedAt >= launchedAt : true
+    }
+
+    private func readClaudeUsageCache(maxAge: TimeInterval, writtenThisSession: Bool = false) -> [String: Any]? {
         let url = claudeUsageCacheURL()
         guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
               let modifiedAt = values.contentModificationDate,
-              Date().timeIntervalSince(modifiedAt) <= maxAge else {
+              Self.claudeCacheCountsAsFresh(modifiedAt: modifiedAt, now: Date(), maxAge: maxAge,
+                                            launchedAt: Self.launchedAt,
+                                            writtenThisSession: writtenThisSession) else {
             return nil
         }
         return readClaudeUsageCacheRaw()
+    }
+
+    /// Drop the cached usage and the saved snapshot when the account that produced them is not the
+    /// one we just read. Without this the previous account's percentages survive the switch: the
+    /// 5-minute cache shows them until it ages out, and the snapshot can show them for up to a day
+    /// whenever a live fetch fails.
+    ///
+    /// Only the desktop path knows an account id (the organization UUID). Claude Code's OAuth token
+    /// rotates on refresh, so it is not a stable identity and that path records nothing — a switch
+    /// made purely through the CLI is still missed. Recording what we do know beats recording
+    /// nothing, and the desktop session is the path most accounts arrive on.
+    func noteClaudeAccount(_ accountID: String) {
+        let url = claudeAccountFileURL()
+        let previous = try? String(contentsOf: url, encoding: .utf8)
+        if let previous, previous != accountID {
+            try? FileManager.default.removeItem(at: claudeUsageCacheURL())
+            try? FileManager.default.removeItem(at: snapshotURL(for: "Claude"))
+        }
+        if previous != accountID {
+            try? FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? accountID.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+
+    private func claudeAccountFileURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Mimir/claude_account")
     }
 
     /// The cached usage JSON regardless of age — used as a deep fallback that is trusted not by

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -563,3 +563,36 @@ final class UsageParsingTests: XCTestCase {
         return "header.\(b64url).signature"
     }
 }
+
+/// The cache-freshness rule: age decides on its own for the deep fallbacks, but a caller choosing
+/// whether to fetch also demands the entry was written by the running process — otherwise a freshly
+/// updated app would show the previous version's numbers until the interval lapsed.
+final class ClaudeCacheFreshnessTests: XCTestCase {
+    private let launch = Date(timeIntervalSince1970: 1_000_000)
+
+    func testEntryFromThisSessionIsFresh() {
+        let written = launch.addingTimeInterval(30)
+        XCTAssertTrue(LiveUsageDataSource.claudeCacheCountsAsFresh(
+            modifiedAt: written, now: written.addingTimeInterval(60), maxAge: 300,
+            launchedAt: launch, writtenThisSession: true))
+    }
+
+    func testEntryFromAnEarlierSessionNeverSkipsTheFetch() {
+        // Young enough by age, but written before launch — the just-updated-app case.
+        let written = launch.addingTimeInterval(-60)
+        XCTAssertFalse(LiveUsageDataSource.claudeCacheCountsAsFresh(
+            modifiedAt: written, now: launch.addingTimeInterval(10), maxAge: 300,
+            launchedAt: launch, writtenThisSession: true))
+        // The deep fallbacks still accept it: they are judged by age alone.
+        XCTAssertTrue(LiveUsageDataSource.claudeCacheCountsAsFresh(
+            modifiedAt: written, now: launch.addingTimeInterval(10), maxAge: 300,
+            launchedAt: launch, writtenThisSession: false))
+    }
+
+    func testAgeStillWins() {
+        let written = launch.addingTimeInterval(30)
+        XCTAssertFalse(LiveUsageDataSource.claudeCacheCountsAsFresh(
+            modifiedAt: written, now: written.addingTimeInterval(301), maxAge: 300,
+            launchedAt: launch, writtenThisSession: true))
+    }
+}


### PR DESCRIPTION
Two ways the cached Claude usage could show numbers that are no longer yours.

## Freshness ignored which run wrote the entry

`readClaudeUsageCache` judged an entry by age alone, so one written by an earlier run could still satisfy the 5-minute check and skip the first fetch. Right after an update that means the new version shows the previous one's numbers until the window lapses.

Freshness now also asks whether the entry was written by the running process — but only for the caller that decides whether to fetch. The deep fallbacks keep judging by age, so the card still fills instantly at launch instead of flashing placeholders.

The rule is a pure function (`claudeCacheCountsAsFresh`), so it is tested without touching the filesystem.

## Switching accounts left the old account's numbers in place

The cache showed them until it aged out, and the snapshot could show them for up to a day whenever a live fetch failed.

The desktop path now records the organization UUID it read and clears both the cache and the snapshot when it changes. Claude Code's OAuth token rotates on refresh, so it is not a stable identity and that path records nothing — a switch made purely through the CLI is still missed. The desktop session is the path most accounts arrive on, and recording what we do know beats recording nothing; the limit is named in the comment rather than left for someone to discover.

## Verification

`swift test` — 103 passed, 3 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
