### PR TITLE
feat(codex): warn before a reset credit lapses

### DIFF
--- a/Sources/Mimir/CodexProvider.swift
+++ b/Sources/Mimir/CodexProvider.swift
@@ -203,10 +203,13 @@ extension LiveUsageDataSource {
             return expiresAt
         }
         guard !credits.isEmpty else { return nil }
-        let caption = credits.min().map {
+        let earliest = credits.min()
+        let caption = earliest.map {
             String(format: String(localized: "first expires in %@"), TimeFormatter.duration(from: $0.timeIntervalSince(now)))
         }
-        return ModelStatus(name: String(localized: "Reset credits"), remainingPercent: 0, resetAt: nil,
+        // `resetAt` carries the earliest expiry: the value row doesn't draw it, but the expiry
+        // warning reads it from here rather than the row's already-formatted caption.
+        return ModelStatus(name: String(localized: "Reset credits"), remainingPercent: 0, resetAt: earliest,
                            valueText: String(credits.count), caption: caption, symbol: "arrow.clockwise")
     }
 

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -652,7 +652,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                            percent: service.weeklyRemainingPercent, resetAt: service.weeklyResetAt)
         }
         checkAntigravityWeeklyRefill()
+        checkResetCreditExpiry()
     }
+
+    /// A reset credit lapses unused if it isn't spent, and it's worth most on a window that's spent
+    /// but not about to reset on its own — so warn while there's still time to use one: 1 day, 5 hours
+    /// and 1 hour before the FIRST credit expires. The last-fired stamp pins the expiry it belongs to,
+    /// so a newly granted credit starts a fresh set of three and a relaunch doesn't re-fire the same one.
+    private func checkResetCreditExpiry() {
+        let row = store.services
+            .filter { $0.isAvailable && !$0.isStale }
+            .flatMap(\.models)
+            .first { $0.valueText != nil && $0.resetAt != nil }
+        guard let row, let expiresAt = row.resetAt else { return }
+
+        let remaining = expiresAt.timeIntervalSinceNow
+        guard remaining > 0,
+              let threshold = Self.resetCreditThresholds.first(where: { remaining <= $0 }) else { return }
+
+        let stamp = "\(Int(expiresAt.timeIntervalSince1970))-\(Int(threshold))"
+        guard UserDefaults.standard.string(forKey: Self.resetCreditNotifiedKey) != stamp else { return }
+        UserDefaults.standard.set(stamp, forKey: Self.resetCreditNotifiedKey)
+
+        sendNotification(
+            identifier: "Codex-resetcredit-\(Int(threshold))",
+            title: String(format: String(localized: "⏳ Reset credit expires in %@"),
+                          TimeFormatter.duration(from: remaining)),
+            body: String(format: String(localized: "You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses."),
+                         row.valueText ?? "1")
+        )
+    }
+
+    /// Ascending, so `first(where:)` picks the tightest bracket the countdown has entered.
+    private static let resetCreditThresholds: [TimeInterval] = [3_600, 5 * 3_600, 86_400]
+    private static let resetCreditNotifiedKey = "codexResetCreditNotified"
 
     private static let agyResetTargetKey = "agyWeeklyResetTarget"      // armed reset we're waiting on
     private static let agyResetNotifiedKey = "agyWeeklyResetNotified"  // reset we've already announced
@@ -786,7 +819,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let service = parts.first.map(String.init) ?? "unknown"
         let isRefill = identifier.hasSuffix("-refilled")
         let window = identifier.contains("weekly") ? "weekly" : "5h"
-        let kind = isRefill ? "refilled" : "low"
+        let kind = identifier.contains("resetcredit") ? "resetcredit" : (isRefill ? "refilled" : "low")
         Telemetry.signal("notification.sent", parameters: [
             "service": service, "window": window, "kind": kind
         ])

--- a/Sources/Mimir/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/en.lproj/Localizable.strings
@@ -90,3 +90,5 @@
 "Enable" = "Enable";
 "~/.claude/settings.json is not valid JSON" = "~/.claude/settings.json is not valid JSON";
 "couldn't write to ~/.claude" = "couldn't write to ~/.claude";
+"⏳ Reset credit expires in %@" = "⏳ Reset credit expires in %@";
+"You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses." = "You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses.";

--- a/Sources/Mimir/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/tr.lproj/Localizable.strings
@@ -90,3 +90,5 @@
 "Enable" = "Etkinleştir";
 "~/.claude/settings.json is not valid JSON" = "~/.claude/settings.json geçerli bir JSON değil";
 "couldn't write to ~/.claude" = "~/.claude klasörüne yazılamadı";
+"⏳ Reset credit expires in %@" = "⏳ Sıfırlama hakkı %@ sonra doluyor";
+"You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses." = "Bekleyen %@ hakkın var. Şimdi kullanırsan tükenmiş pencereyi sıfırlar; kullanmazsan yanar.";

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -164,6 +164,8 @@ final class UsageParsingTests: XCTestCase {
         XCTAssertEqual(row?.valueText, "2")
         XCTAssertEqual(row?.caption, String(format: String(localized: "first expires in %@"),
                                             TimeFormatter.duration(from: 3 * 86_400)))
+        // The expiry warning reads the nearest expiry off `resetAt`, not the formatted caption.
+        XCTAssertEqual(row?.resetAt, credalNow.addingTimeInterval(3 * 86_400))
     }
 
     /// A credit that lapsed between polls, and one that was already spent, are both dropped —


### PR DESCRIPTION
Codex hands out **reset credits** — one-shot passes that clear a spent rate-limit window. They expire on their own if unused, and Mimir only ever showed the count with a formatted "first expires in 3d" caption, so a credit could quietly lapse while a weekly window sat at 20% with three days still to run.

This notifies at **1 day, 5 hours and 1 hour** before the first credit expires.

### How it works

- `codexResetCreditRow` now carries the nearest expiry in the row's (previously unused) `resetAt`. The value row doesn't draw it, so nothing changes visually — the warning reads the date instead of re-parsing its own caption.
- `checkResetCreditExpiry` runs with the existing notification checks, picking the tightest bracket the countdown has entered.
- The last-fired stamp pins the expiry it belongs to, so a newly granted credit starts a fresh set of three and an app relaunch doesn't re-fire one already sent.
- Telemetry reports these as `kind: "resetcredit"` rather than mislabelling them `low`.

### Notes

- The warning fires regardless of how full the windows are — a credit about to lapse is worth knowing about either way. Gating it on a spent window is a two-line change if preferred.
- EN + TR strings included.

### Test plan

- `swift test` — 103 tests, 0 failures.
- Added an assertion that the row exposes the nearest expiry on `resetAt`; the threshold pick itself is a single `first(where:)` over a constant list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)