### PR TITLE
chore: drop the last Medium widget references from comments

### DIFF
--- a/Sources/Mimir/MimirModels.swift
+++ b/Sources/Mimir/MimirModels.swift
@@ -28,7 +28,7 @@ struct ServiceStatus: Identifiable {
     let cooldownHint: TimeInterval?
     /// True when the live source has been unreachable long enough (>15 min) that the last-known data
     /// is no longer trustworthy — the UI shows an actionable "couldn't fetch" state (small widget
-    /// message / medium "—" / popover banner) instead of stale numbers. The model labels are kept so
+    /// message / popover banner) instead of stale numbers. The model labels are kept so
     /// those surfaces still know which rows to render.
     let dataUnavailable: Bool
 

--- a/Sources/MimirShared/WidgetPayload.swift
+++ b/Sources/MimirShared/WidgetPayload.swift
@@ -23,7 +23,7 @@ public struct ProviderPayload: Codable, Equatable {
     public var isAvailable: Bool
     public var fiveHour: [WindowMetric]   // the prominent 5h windows (1 for Claude/Codex, 2 for AG)
     // The live source has been unreachable too long to trust the last reading: the widget renders an
-    // actionable "couldn't fetch" state (small message / medium "—") instead of stale numbers. The
+    // actionable "couldn't fetch" state (a message in place of the numbers) instead of stale ones. The
     // `fiveHour` labels are still carried so the rows know what to render.
     public var unavailable: Bool
     // Last-known reading shown while the live source is briefly unusable — e.g. Claude's access token


### PR DESCRIPTION
The Medium widget was removed in #53 — `supportedFamilies` is `[.systemSmall]` and no code path builds one. Two doc comments still described the data-unavailable state as "small message / medium —", which now points at a widget that doesn't exist.

Comment-only change; no behaviour touched. `swift build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)