### PR TITLE
fix(codex): stop the monthly quota firing false alerts, and show renewal credits by expiry

### DIFF
--- a/Sources/Mimir/CodexProvider.swift
+++ b/Sources/Mimir/CodexProvider.swift
@@ -137,13 +137,16 @@ extension LiveUsageDataSource {
     func codexStatus(fromUsageRoot root: [String: Any], now: Date = Date(), extraRows: [ModelStatus] = []) -> ServiceStatus {
         let rateLimit = root["rate_limit"] as? [String: Any] ?? [:]
 
-        var session: (percent: Int, resetAt: Date?)?
-        var weekly: (percent: Int, resetAt: Date?)?
+        var session: (percent: Int?, resetAt: Date?)?
+        var weekly: (percent: Int?, resetAt: Date?)?
         var weeklyWindow: TimeInterval?
         for (raw, slotIsPrimary) in [(rateLimit["primary_window"], true), (rateLimit["secondary_window"], false)] {
             guard let obj = raw as? [String: Any] else { continue }
             let window = codexAPIWindow(obj)
-            let percent = window.usedPercent.map(remainingPercent(fromUsed:)) ?? 100
+            // A window returned without `used_percent` has an UNKNOWN percent, not a full one. Reading it
+            // as 100 made a partial response look like a fresh reset, which fired "quota refilled" in the
+            // middle of a 30-day (Go) window. nil keeps the countdown and drops only the number.
+            let percent = window.usedPercent.map(remainingPercent(fromUsed:))
             let periodSeconds = doubleValue(obj["limit_window_seconds"])
             let isSession = codexWindowIsSession(periodSeconds: periodSeconds,
                                                  resetAt: window.resetAt,
@@ -164,8 +167,8 @@ extension LiveUsageDataSource {
             iconName: "codex",
             sessionResetAt: session?.resetAt,
             weeklyResetAt: weekly?.resetAt,
-            sessionRemainingPercent: session?.percent,
-            weeklyRemainingPercent: weekly?.percent,
+            sessionRemainingPercent: session.flatMap(\.percent),
+            weeklyRemainingPercent: weekly.flatMap(\.percent),
             weeklyWindowSeconds: weeklyWindow,
             models: (codexCreditRow(root["credits"]).map { [$0] } ?? []) + extraRows,
             isAvailable: true,

--- a/Sources/Mimir/CodexProvider.swift
+++ b/Sources/Mimir/CodexProvider.swift
@@ -120,8 +120,8 @@ extension LiveUsageDataSource {
                   root["rate_limit"] is [String: Any] else {
                 return nil
             }
-            let resetRow = await fetchCodexResetCredits(accessToken: accessToken, accountID: accountID)
-            return codexStatus(fromUsageRoot: root, extraRows: resetRow.map { [$0] } ?? [])
+            let resetRows = await fetchCodexResetCredits(accessToken: accessToken, accountID: accountID)
+            return codexStatus(fromUsageRoot: root, extraRows: resetRows)
         } catch {
             return nil
         }
@@ -194,31 +194,42 @@ extension LiveUsageDataSource {
                            symbol: "dollarsign.circle")
     }
 
-    /// Reset credits ("sıfırlama hakkı") from `wham/rate-limit-reset-credits`: one-shot passes that
-    /// clear a spent rate-limit window. Only credits still available AND not yet expired count — a
-    /// credit can lapse between polls, and `available_count` doesn't re-check that.
-    /// Returns nil when there are none, so the row is simply omitted.
-    func codexResetCreditRow(fromRoot root: [String: Any], now: Date = Date()) -> ModelStatus? {
-        let credits = (root["credits"] as? [[String: Any]] ?? []).compactMap { item -> Date? in
+    /// Reset credits ("yenileme hakkı") from `wham/rate-limit-reset-credits`: one-shot passes that
+    /// clear a spent rate-limit window. One row per credit, soonest expiry first — a count alone hid
+    /// the fact that credits expire on their own dates, and the "first expires in …" caption read
+    /// oddly when there was only one. Only credits still available AND not yet expired count: a credit
+    /// can lapse between polls, and `available_count` doesn't re-check that. Empty → no rows at all.
+    func codexResetCreditRows(fromRoot root: [String: Any], now: Date = Date()) -> [ModelStatus] {
+        let expiries = (root["credits"] as? [[String: Any]] ?? []).compactMap { item -> Date? in
             guard (item["status"] as? String)?.lowercased() == "available",
                   let raw = item["expires_at"] as? String,
                   let expiresAt = parseISO8601(raw), expiresAt > now else { return nil }
             return expiresAt
+        }.sorted()
+
+        // One line per credit, labelled by the date it lapses; the popover groups them under a single
+        // "Renewal credits" heading, so neither the icon nor the label repeats. `resetAt` carries the
+        // expiry: the line draws a live countdown off it, and the expiry warning reads it from here
+        // rather than from the formatted text.
+        return expiries.map { expiresAt in
+            ModelStatus(name: Self.creditDateFormatter.string(from: expiresAt),
+                        remainingPercent: 0, resetAt: expiresAt,
+                        valueText: TimeFormatter.duration(from: expiresAt.timeIntervalSince(now)))
         }
-        guard !credits.isEmpty else { return nil }
-        let earliest = credits.min()
-        let caption = earliest.map {
-            String(format: String(localized: "first expires in %@"), TimeFormatter.duration(from: $0.timeIntervalSince(now)))
-        }
-        // `resetAt` carries the earliest expiry: the value row doesn't draw it, but the expiry
-        // warning reads it from here rather than the row's already-formatted caption.
-        return ModelStatus(name: String(localized: "Reset credits"), remainingPercent: 0, resetAt: earliest,
-                           valueText: String(credits.count), caption: caption, symbol: "arrow.clockwise")
     }
+
+    /// Locale's own short date ("19.10.2026" in tr, "10/19/2026" in en) — a credit's expiry is a
+    /// calendar date, not a countdown, so it reads as one.
+    static let creditDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .short
+        f.timeStyle = .none
+        return f
+    }()
 
     /// GET the reset-credit endpoint with the same auth as `wham/usage`. Failure returns nil and the
     /// row is dropped — this is a bonus reading, never a reason to fail the whole Codex fetch.
-    private func fetchCodexResetCredits(accessToken: String, accountID: String?) async -> ModelStatus? {
+    private func fetchCodexResetCredits(accessToken: String, accountID: String?) async -> [ModelStatus] {
         var req = URLRequest(url: URL(string: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")!,
                              timeoutInterval: 10)
         req.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
@@ -231,9 +242,9 @@ extension LiveUsageDataSource {
         guard let (data, response) = try? await URLSession.shared.data(for: req),
               (response as? HTTPURLResponse).map({ 200 ... 299 ~= $0.statusCode }) == true,
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
+            return []
         }
-        return codexResetCreditRow(fromRoot: root)
+        return codexResetCreditRows(fromRoot: root)
     }
     private func summarizeCodexWindow(_ window: CodexRateWindow?, now: Date) -> CodexWindowSummary? {
         guard let window else { return nil }

--- a/Sources/Mimir/DemoShot.swift
+++ b/Sources/Mimir/DemoShot.swift
@@ -1,0 +1,59 @@
+#if DEBUG
+import AppKit
+import SwiftUI
+
+/// Throwaway: renders the popover's cards to a PNG so a UI change can be reviewed without running
+/// the menu-bar app. `MIMIR_DEMO_SHOT=/tmp/shot.png .build/debug/Mimir`. Not for release.
+enum DemoShot {
+    @MainActor
+    static func render(to path: String) {
+        let now = Date()
+        let claude = ServiceStatus(
+            name: "Claude", iconName: "claude",
+            sessionResetAt: now.addingTimeInterval(4 * 3600 + 23 * 60),
+            weeklyResetAt: now.addingTimeInterval(3 * 86_400 + 19 * 3600),
+            sessionRemainingPercent: 92, weeklyRemainingPercent: 99,
+            models: [
+                ModelStatus(name: "Fable", remainingPercent: 100,
+                            resetAt: now.addingTimeInterval(3 * 86_400 + 19 * 3600), window: .weekly),
+            ],
+            isAvailable: true, statusNote: "demo")
+
+        let credits = LiveUsageDataSource().codexResetCreditRows(fromRoot: [
+            "credits": [
+                ["status": "available", "expires_at": iso(now.addingTimeInterval(3 * 86_400 + 19 * 3600))],
+                ["status": "available", "expires_at": iso(now.addingTimeInterval(9 * 86_400 + 4 * 3600))],
+            ],
+        ], now: now)
+
+        let codex = ServiceStatus(
+            name: "Codex", iconName: "codex",
+            sessionResetAt: now.addingTimeInterval(13 * 60),
+            weeklyResetAt: now.addingTimeInterval(6 * 86_400 + 13 * 3600),
+            sessionRemainingPercent: 91, weeklyRemainingPercent: 91,
+            weeklyWindowSeconds: 2_592_000,
+            models: credits,
+            isAvailable: true, statusNote: "demo")
+
+        let view = VStack(spacing: 11) {
+            ServiceCard(service: claude, now: now)
+            ServiceCard(service: codex, now: now)
+        }
+        .padding(11)
+        .frame(width: PopoverMetrics.width)
+        .background(Color(hex: 0x2C2C30))
+        .environment(\.colorScheme, .dark)
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        guard let image = renderer.nsImage,
+              let tiff = image.tiffRepresentation,
+              let png = NSBitmapImageRep(data: tiff)?.representation(using: .png, properties: [:]) else {
+            return
+        }
+        try? png.write(to: URL(fileURLWithPath: path))
+    }
+
+    private static func iso(_ date: Date) -> String { ISO8601DateFormatter().string(from: date) }
+}
+#endif

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -53,11 +53,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var resignObserver: NSObjectProtocol?
     private var cancellables: Set<AnyCancellable> = []
     private var updaterController: SPUStandardUpdaterController?
-    // Per-window notification state, keyed "<service>-5h" / "<service>-weekly".
-    private var lowNotified: Set<String> = []     // window is below its low threshold (until it resets)
-    private var depleted5h: Set<String> = []      // service's 5h window hit 0% since its last refill
-    private var depletedWeekly: Set<String> = []  // service's weekly ran below its low threshold since refill
-    private var lastWindowPercent: [String: Int] = [:]  // previous reading, for refill edge detection
+    // Per-window notification state lives in UserDefaults (see `notifState`), keyed
+    // "<service>-5h" / "<service>-weekly" — a relaunch must not re-fire an alert already sent.
     private var iconSource: NSImage?
     private var refreshCount = 0              // refreshes seen this session (for the provider signal)
     private var sentProviderSignal = false   // provider.active is emitted once per session
@@ -641,15 +638,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func checkNotifications() {
         // Only the account-level 5h + weekly windows of genuinely LIVE services notify here. The
         // `!isStale` guard is load-bearing: a card served from a snapshot / a refilled estimate is
-        // `isStale`, so it never fires a low/refill alert on inferred numbers — otherwise a card
-        // bouncing between a live reading and a refilled 100 would spam false "quota refilled" alerts.
-        // A genuine reset is still caught: a LIVE fetch (which never reset-classifies) reports the real
-        // 100. Antigravity is excluded by name (no service-level windows; it uses per-group model rows).
+        // `isStale`, so a low alert is never raised off an inferred number. Refills fire off the
+        // window's reset clock (see `fireRefillIfDue`), so a reading flickering back to 100 can't
+        // announce one. Antigravity is excluded by name (no service-level windows; per-group rows).
         for service in store.services where service.isAvailable && !service.isStale && service.name != "Antigravity" {
             evaluateWindow(service: service, window: .fiveHour,
                            percent: service.sessionRemainingPercent, resetAt: service.sessionResetAt)
             evaluateWindow(service: service, window: .weekly,
-                           percent: service.weeklyRemainingPercent, resetAt: service.weeklyResetAt)
+                           percent: service.weeklyRemainingPercent, resetAt: service.weeklyResetAt,
+                           windowSeconds: service.weeklyWindowSeconds)
         }
         checkAntigravityWeeklyRefill()
         checkResetCreditExpiry()
@@ -687,9 +684,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let resetCreditThresholds: [TimeInterval] = [3_600, 5 * 3_600, 86_400]
     private static let resetCreditNotifiedKey = "codexResetCreditNotified"
 
-    private static let agyResetTargetKey = "agyWeeklyResetTarget"      // armed reset we're waiting on
-    private static let agyResetNotifiedKey = "agyWeeklyResetNotified"  // reset we've already announced
-
     /// HH:mm for the 5-hour low notification's reset clock.
     private static let clockFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -697,128 +691,155 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return f
     }()
 
+    // MARK: - Persisted per-window notification state
+
+    /// One `UserDefaults` number per field, namespaced by the window key ("Codex-weekly.armed").
+    /// Fields: `armed` (the reset we're waiting to announce), `announced` (the one already announced),
+    /// `low` (the reset whose low alert already went out), `depleted` (1 once the window was really
+    /// run down). Kept on disk because these alerts are once-per-window, not once-per-launch: in
+    /// memory, every relaunch re-sent the same "running out" notice.
+    private func notifState(_ key: String, _ field: String) -> Double {
+        UserDefaults.standard.double(forKey: "notif.\(key).\(field)")
+    }
+
+    private func setNotifState(_ key: String, _ field: String, _ value: Double) {
+        UserDefaults.standard.set(value, forKey: "notif.\(key).\(field)")
+    }
+
+    /// Announce a refill when the armed reset has passed, then disarm so the next one can arm cleanly.
+    /// `requireDepleted` is false only for Antigravity, whose usage can't be observed while its IDE is
+    /// closed — there the reset clock is all we have.
+    private func fireRefillIfDue(key: String, bucket: String, requireDepleted: Bool,
+                                 title: String, body: String) {
+        let armed = notifState(key, "armed")
+        guard refillIsDue(armed: armed, announced: notifState(key, "announced"),
+                          now: Date().timeIntervalSince1970) else { return }
+        if !requireDepleted || notifState(key, "depleted") == 1 {
+            sendNotification(identifier: "\(key)-refilled", window: bucket, title: title, body: body)
+        }
+        setNotifState(key, "announced", armed)
+        setNotifState(key, "depleted", 0)
+        setNotifState(key, "armed", 0)
+    }
+
+    private func armNextReset(key: String, resetAt: Date?) {
+        guard let stamp = nextArmedReset(armed: notifState(key, "armed"),
+                                         announced: notifState(key, "announced"),
+                                         resetAt: resetAt, now: Date()) else { return }
+        setNotifState(key, "armed", stamp)
+    }
+
     /// Antigravity's one reliable notification: the weekly quota refill. Its weekly reset time is
     /// deterministic and known in advance, and the quota can't be spent while the IDE is closed —
     /// so once we've seen the reset time, we can fire "refilled" exactly when it passes, with no
     /// live data. (Low / 5h alerts stay off: those depend on usage we can't observe reliably.)
     private func checkAntigravityWeeklyRefill() {
-        let defaults = UserDefaults.standard
-        let now = Date()
+        let key = "Antigravity-weekly"
+        fireRefillIfDue(
+            key: key, bucket: "weekly", requireDepleted: false,
+            title: String(format: String(localized: "🚀 %@ weekly quota refilled."), "Antigravity"),
+            body: String(localized: "Your weekly quota is back to 100%. Pick up where you left off.")
+        )
 
-        // Fire when the armed reset has passed, then disarm so the next reset can arm cleanly.
-        let armed = defaults.double(forKey: Self.agyResetTargetKey)
-        if armed > 0, now.timeIntervalSince1970 >= armed {
-            if defaults.double(forKey: Self.agyResetNotifiedKey) != armed {
-                sendNotification(
-                    identifier: "Antigravity-weekly-refilled",
-                    title: String(format: String(localized: "🚀 %@ weekly quota refilled."), "Antigravity"),
-                    body: String(localized: "Your weekly quota is back to 100%. Pick up where you left off.")
-                )
-                defaults.set(armed, forKey: Self.agyResetNotifiedKey)
-            }
-            defaults.removeObject(forKey: Self.agyResetTargetKey)
-        }
-
-        // Arm the next future weekly reset (both weekly buckets share one time → take the earliest).
-        // Only when nothing is armed and only a reset we haven't already announced, so the data
-        // jumping to next week at reset time can't clobber the reset we still owe a notification for.
-        guard defaults.double(forKey: Self.agyResetTargetKey) == 0,
-              let antigravity = store.services.first(where: { $0.name == "Antigravity" }) else {
-            return
-        }
-        let upcoming = antigravity.models
+        guard let antigravity = store.services.first(where: { $0.name == "Antigravity" }) else { return }
+        // Both weekly buckets share one reset time → take the earliest still ahead of us.
+        armNextReset(key: key, resetAt: antigravity.models
             .filter { $0.window == .weekly }
             .compactMap(\.resetAt)
-            .filter { $0 > now }
-            .min()
-        if let upcoming, upcoming.timeIntervalSince1970 != defaults.double(forKey: Self.agyResetNotifiedKey) {
-            defaults.set(upcoming.timeIntervalSince1970, forKey: Self.agyResetTargetKey)
-        }
+            .filter { $0 > Date() }
+            .min())
     }
 
-    private func evaluateWindow(service: ServiceStatus, window: QuotaWindow, percent: Int?, resetAt: Date?) {
+    private func evaluateWindow(service: ServiceStatus, window: QuotaWindow, percent: Int?, resetAt: Date?,
+                                windowSeconds: TimeInterval? = nil) {
         guard let percent else { return }
         let key = "\(service.name)-\(window.suffix)"
-        let previous = lastWindowPercent[key]
-        lastWindowPercent[key] = percent
+        // A window longer than a week is the ChatGPT Go monthly quota, not a weekly one — say so, and
+        // report it as its own telemetry bucket rather than folding it into "weekly".
+        let isMonthly = window == .weekly && (windowSeconds ?? 0) > 8 * 86_400
+        let bucket = isMonthly ? "monthly" : window.suffix
+        // The 5h window keeps its flat 20%; a longer one scales its threshold by length (see
+        // `lowQuotaThreshold`) so a 30-day quota doesn't warn on day three.
+        let lowThreshold = window == .fiveHour
+            ? window.lowThreshold
+            : lowQuotaThreshold(windowSeconds: windowSeconds, base: window.lowThreshold)
 
-        // A refill notice is only meaningful (and only trustworthy) if the window was actually run down
-        // first — mirror the 5h `== 0` guard for the weekly, using its low threshold. Without this, a
-        // momentary blip to 100 (a stale-refill estimate, or a partial/late read) on a window sitting at
-        // 76% would announce a "refill" that never happened.
-        if window == .fiveHour, percent == 0 {
-            depleted5h.insert(service.name)
-        }
-        if window == .weekly, percent < window.lowThreshold {
-            depletedWeekly.insert(service.name)
+        // A refill notice is only meaningful on a window that was actually run down first: spent for
+        // the 5h one, below its low threshold for the longer one.
+        if percent < (window == .fiveHour ? 1 : lowThreshold) {
+            setNotifState(key, "depleted", 1)
         }
 
-        // Refill: the window jumped back to 100 (a reset). Edge-triggered on the <100 → 100 crossing so
-        // it fires once per reset, never on the first reading (previous == nil), and only when the
-        // window had genuinely been depleted since its last refill.
-        if percent == 100, let previous, previous < 100 {
-            switch window {
-            case .fiveHour:
-                if depleted5h.contains(service.name) {
-                    sendNotification(
-                        identifier: "\(key)-refilled",
-                        title: String(format: String(localized: "🔋 %@ ready for a new sprint."), service.name),
-                        body: String(localized: "Your 5-hour session is back to 100%. Pick up where you left off.")
-                    )
-                }
-                depleted5h.remove(service.name)
-            case .weekly:
-                if depletedWeekly.contains(service.name) {
-                    sendNotification(
-                        identifier: "\(key)-refilled",
-                        title: String(format: String(localized: "🚀 %@ weekly quota refilled."), service.name),
-                        body: String(localized: "Your weekly quota is back to 100%. Pick up where you left off.")
-                    )
-                }
-                depletedWeekly.remove(service.name)
+        // Refill: the window's reset came round. Fires once per reset, on the clock rather than on the
+        // percent — a reading flickering back to 100 is not a reset.
+        switch window {
+        case .fiveHour:
+            fireRefillIfDue(
+                key: key, bucket: bucket, requireDepleted: true,
+                title: String(format: String(localized: "🔋 %@ ready for a new sprint."), service.name),
+                body: String(localized: "Your 5-hour session is back to 100%. Pick up where you left off.")
+            )
+        case .weekly:
+            fireRefillIfDue(
+                key: key, bucket: bucket, requireDepleted: true,
+                title: String(format: isMonthly
+                              ? String(localized: "🚀 %@ monthly quota refilled.")
+                              : String(localized: "🚀 %@ weekly quota refilled."), service.name),
+                body: isMonthly
+                    ? String(localized: "Your monthly quota is back to 100%. Pick up where you left off.")
+                    : String(localized: "Your weekly quota is back to 100%. Pick up where you left off.")
+            )
+        }
+        armNextReset(key: key, resetAt: resetAt)
+
+        // Low: crossed below the threshold. Warn once per window — the stored stamp is the reset the
+        // warning belongs to, so the next window warns again and a relaunch inside this one doesn't.
+        // A service that reports no reset at all stores 0 and so warns only once, until one appears.
+        let lowKey = "notif.\(key).low"
+        let resetStamp = resetAt?.timeIntervalSince1970 ?? 0
+        guard percent < lowThreshold,
+              UserDefaults.standard.object(forKey: lowKey) as? Double != resetStamp else { return }
+        UserDefaults.standard.set(resetStamp, forKey: lowKey)
+
+        let duration = resetAt.map { TimeFormatter.duration(from: $0.timeIntervalSinceNow) }
+        switch window {
+        case .fiveHour:
+            // 5h includes the reset clock (it's today) plus the countdown.
+            let body: String
+            if let resetAt, let duration {
+                body = String(format: String(localized: "Resets at %@. ~%@ to go."),
+                              Self.clockFormatter.string(from: resetAt), duration)
+            } else {
+                body = String(localized: "Your 5-hour limit is running out.")
             }
-            lowNotified.remove(key)
-            return
-        }
-
-        // Low: crossed below the threshold. Warn once, then stay quiet until the window resets.
-        if percent < window.lowThreshold, !lowNotified.contains(key) {
-            let duration = resetAt.map { TimeFormatter.duration(from: $0.timeIntervalSinceNow) }
-            switch window {
-            case .fiveHour:
-                // 5h includes the reset clock (it's today) plus the countdown.
-                let body: String
-                if let resetAt, let duration {
-                    body = String(format: String(localized: "Resets at %@. ~%@ to go."),
-                                  Self.clockFormatter.string(from: resetAt), duration)
-                } else {
-                    body = String(localized: "Your 5-hour limit is running out.")
-                }
-                sendNotification(
-                    identifier: key,
-                    title: String(format: String(localized: "🪫 %@ 5-hour quota running out — %d%%"), service.name, percent),
-                    body: body
-                )
-            case .weekly:
-                // Weekly is days out, so just the countdown (no clock).
-                let body = duration.map { String(format: String(localized: "Renews in ~%@."), $0) }
-                    ?? String(localized: "Your weekly limit is running out.")
-                sendNotification(
-                    identifier: key,
-                    title: String(format: String(localized: "🚨 %@ weekly quota running out — %d%%"), service.name, percent),
-                    body: body
-                )
-            }
-            lowNotified.insert(key)
+            sendNotification(
+                identifier: key,
+                window: bucket,
+                title: String(format: String(localized: "🪫 %@ 5-hour quota running out — %d%%"), service.name, percent),
+                body: body
+            )
+        case .weekly:
+            // Weekly/monthly is days out, so just the countdown (no clock).
+            let body = duration.map { String(format: String(localized: "Renews in ~%@."), $0) }
+                ?? (isMonthly ? String(localized: "Your monthly limit is running out.")
+                              : String(localized: "Your weekly limit is running out."))
+            sendNotification(
+                identifier: key,
+                window: bucket,
+                title: String(format: isMonthly
+                              ? String(localized: "🚨 %@ monthly quota running out — %d%%")
+                              : String(localized: "🚨 %@ weekly quota running out — %d%%"), service.name, percent),
+                body: body
+            )
         }
     }
 
-    private func sendNotification(identifier: String, title: String, body: String) {
+    private func sendNotification(identifier: String, window: String? = nil, title: String, body: String) {
         // Derive a categorical type from the identifier: "Claude-5h", "Codex-weekly-refilled", etc.
         let parts = identifier.split(separator: "-")
         let service = parts.first.map(String.init) ?? "unknown"
         let isRefill = identifier.hasSuffix("-refilled")
-        let window = identifier.contains("weekly") ? "weekly" : "5h"
+        let window = window ?? (identifier.contains("weekly") ? "weekly" : "5h")
         let kind = identifier.contains("resetcredit") ? "resetcredit" : (isRefill ? "refilled" : "low")
         Telemetry.signal("notification.sent", parameters: [
             "service": service, "window": window, "kind": kind

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -566,8 +566,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func statusNSColor(_ percent: Int) -> NSColor {
         switch max(0, min(100, percent)) {
-        case 50...100: return NSColor(hex: 0x3FB984)  // green
-        case 15..<50:  return NSColor(hex: 0xE0A93C)  // amber
+        case 40...100: return NSColor(hex: 0x3FB984)  // green
+        case 10..<40:  return NSColor(hex: 0xE0A93C)  // amber
         default:       return NSColor(hex: 0xE5564E)  // red
         }
     }
@@ -632,7 +632,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private enum QuotaWindow {
         case fiveHour, weekly
         var suffix: String { self == .fiveHour ? "5h" : "weekly" }
-        var lowThreshold: Int { self == .fiveHour ? 20 : 10 }
+        var lowThreshold: Int { 10 }
     }
 
     private func checkNotifications() {

--- a/Sources/Mimir/MimirApp.swift
+++ b/Sources/Mimir/MimirApp.swift
@@ -81,6 +81,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        #if DEBUG
+        if let shot = ProcessInfo.processInfo.environment["MIMIR_DEMO_SHOT"] {
+            DemoShot.render(to: shot)
+            NSApp.terminate(nil)
+            return
+        }
+        #endif
         // Dev builds (com.erayendes.mimir.dev) must not report to the production
         // Sentry project — their crashes/hangs are just local development noise (MIMIR-7).
         let isDevBuild = Bundle.main.bundleIdentifier?.hasSuffix(".dev") ?? false
@@ -657,11 +664,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// and 1 hour before the FIRST credit expires. The last-fired stamp pins the expiry it belongs to,
     /// so a newly granted credit starts a fresh set of three and a relaunch doesn't re-fire the same one.
     private func checkResetCreditExpiry() {
-        let row = store.services
+        let rows = store.services
             .filter { $0.isAvailable && !$0.isStale }
             .flatMap(\.models)
-            .first { $0.valueText != nil && $0.resetAt != nil }
-        guard let row, let expiresAt = row.resetAt else { return }
+            .filter { $0.valueText != nil && $0.resetAt != nil }
+        guard let expiresAt = rows.compactMap(\.resetAt).min() else { return }
 
         let remaining = expiresAt.timeIntervalSinceNow
         guard remaining > 0,
@@ -676,7 +683,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             title: String(format: String(localized: "⏳ Reset credit expires in %@"),
                           TimeFormatter.duration(from: remaining)),
             body: String(format: String(localized: "You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses."),
-                         row.valueText ?? "1")
+                         String(rows.count))
         )
     }
 

--- a/Sources/Mimir/MimirModels.swift
+++ b/Sources/Mimir/MimirModels.swift
@@ -267,3 +267,35 @@ enum TimeFormatter {
         return "\(max(minutes, 1))\(minute)"
     }
 }
+
+/// Has the reset we armed come round? A refill is announced off the window's own reset CLOCK rather
+/// than off a percent jumping back to 100 — a reading can flicker to full for reasons that aren't a
+/// reset (a partial response, the local session file standing in for the usage API), which is what
+/// announced "quota refilled" mid-month on a 30-day ChatGPT Go window. `announced` pins the reset we
+/// already told the user about, so a relaunch can't repeat it.
+func refillIsDue(armed: Double, announced: Double, now: Double) -> Bool {
+    armed > 0 && now >= armed && announced != armed
+}
+
+/// The reset to arm next, or nil to leave the current arming alone: only when nothing is armed, the
+/// reset is still in the future, and it isn't the one already announced (so the data rolling forward
+/// at reset time can't clobber a refill we still owe).
+func nextArmedReset(armed: Double, announced: Double, resetAt: Date?, now: Date) -> Double? {
+    guard armed == 0, let resetAt else { return nil }
+    let stamp = resetAt.timeIntervalSince1970
+    guard stamp > now.timeIntervalSince1970, stamp != announced else { return nil }
+    return stamp
+}
+
+/// Remaining-percent at which a long quota window counts as "running out". Anchored on the 7-day
+/// week's 10%: a flat percent warns far too early on a longer window — 10% of a 30-day ChatGPT Go
+/// quota is three days' worth of budget still in hand, announced as if the month were over. Scaling
+/// by length puts the warning at a comparable time-to-empty instead, with a 5% floor so it can never
+/// tighten to the point of arriving too late to act on. Windows at or under the base keep the base.
+func lowQuotaThreshold(windowSeconds: TimeInterval?,
+                       base: Int = 10,
+                       baseWindow: TimeInterval = 7 * 86_400,
+                       floor: Int = 5) -> Int {
+    guard let windowSeconds, windowSeconds > baseWindow else { return base }
+    return max(floor, Int((Double(base) * baseWindow / windowSeconds).rounded()))
+}

--- a/Sources/Mimir/PopoverViews.swift
+++ b/Sources/Mimir/PopoverViews.swift
@@ -563,14 +563,14 @@ struct QuotaBar: View {
     }
 }
 
-/// Status colour for a remaining-quota level, per the design spec's thresholds: green ≥50%,
-/// amber 15–49%, red ≤14% — one set of bands for every window. Returns a dynamic colour that
+/// Status colour for a remaining-quota level, per the design spec's thresholds: green ≥40%,
+/// amber 10–39%, red ≤9% — one set of bands for every window. Returns a dynamic colour that
 /// darkens in light mode so it stays legible on the light panel.
 func quotaStatusColor(_ percent: Int) -> Color {
     let darkHex: UInt32, lightHex: UInt32
     switch clampPct(percent) {
-    case 50...100: darkHex = 0x3FB984; lightHex = 0x1FA45E  // green
-    case 15...49:  darkHex = 0xE0A93C; lightHex = 0xB07D0A  // amber
+    case 40...100: darkHex = 0x3FB984; lightHex = 0x1FA45E  // green
+    case 10...39:  darkHex = 0xE0A93C; lightHex = 0xB07D0A  // amber
     default:       darkHex = 0xE5564E; lightHex = 0xC9403A  // red
     }
     return Color(nsColor: NSColor(name: nil) { appearance in

--- a/Sources/Mimir/PopoverViews.swift
+++ b/Sources/Mimir/PopoverViews.swift
@@ -335,11 +335,24 @@ struct ServiceCard: View {
                 }
             }
 
-            if !valueRows.isEmpty {
+            if !valueRows.isEmpty || !creditRows.isEmpty {
                 cardDivider.padding(.top, 11).padding(.bottom, 9)
                 VStack(alignment: .leading, spacing: 7) {
                     ForEach(valueRows) { row in
                         valueRow(row)
+                    }
+                    if !creditRows.isEmpty {
+                        // One heading for the whole group, then a line per credit — repeating the icon
+                        // and the label on every line read as noise.
+                        HStack(spacing: 5) {
+                            Image(systemName: "arrow.clockwise").font(.system(size: 11, weight: .regular))
+                            Text(String(localized: "Renewal credits"))
+                        }
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color.primary.opacity(0.58))
+                        ForEach(creditRows) { row in
+                            creditRow(row)
+                        }
                     }
                 }
             }
@@ -399,6 +412,21 @@ struct ServiceCard: View {
         .lineLimit(1)
     }
 
+    /// One renewal credit: the date it lapses, and how long that is from now.
+    private func creditRow(_ row: ModelStatus) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(row.name)
+                .font(.system(size: 11, weight: .medium).monospacedDigit())
+                .foregroundStyle(Color.primary.opacity(0.58))
+            Spacer(minLength: 6)
+            // Same quiet grey as a model row's countdown — the date is the content here, not the clock.
+            Text(relDuration(row.resetAt, now) ?? row.valueText ?? "")
+                .font(.system(size: 11, weight: .medium).monospacedDigit())
+                .foregroundStyle(Color.primary.opacity(0.42))
+        }
+        .lineLimit(1)
+    }
+
     // MARK: Data shaping
 
     /// Codex is branded "ChatGPT" on the card — that's the account the quota belongs to.
@@ -413,7 +441,8 @@ struct ServiceCard: View {
         // The account weekly is a row only when there IS a 5h block above it; with no session the
         // weekly is promoted into the block (see sessionHero), so don't repeat it here.
         if service.sessionRemainingPercent != nil, let weekly = service.weeklyRemainingPercent {
-            out.append((String(localized: "All models"), weekly, service.weeklyResetAt))
+            let label = (labelsByWindow ? longWindowLabel : nil) ?? String(localized: "All models")
+            out.append((label, weekly, service.weeklyResetAt))
         }
         for model in service.models where model.valueText == nil {
             out.append((model.name, model.remainingPercent, model.resetAt))
@@ -426,19 +455,27 @@ struct ServiceCard: View {
     /// a label that says so, rather than leaving the card without a headline number.
     private var sessionHero: (label: String, percent: Int, resetAt: Date?, fallback: TimeInterval, gated: Bool)? {
         if let session = service.sessionRemainingPercent {
-            return (String(localized: "Current session"), session, service.sessionResetAt,
+            let label = labelsByWindow ? sessionWindowLabel : String(localized: "Current session")
+            return (label, session, service.sessionResetAt,
                     5 * 3600, service.weeklyRemainingPercent == 0)
         }
         if let weekly = service.weeklyRemainingPercent {
-            return (String(localized: "Usage limits"), weekly, service.weeklyResetAt,
+            let label = (labelsByWindow ? longWindowLabel : nil) ?? String(localized: "Usage limits")
+            return (label, weekly, service.weeklyResetAt,
                     service.weeklyWindowSeconds ?? 7 * 24 * 3600, false)
         }
         return nil
     }
 
     /// Credit / reset-credit rows, in provider order. Empty → the whole section is skipped.
+    /// Value rows that stand on their own (the credit balance): a labelled row with its own icon.
     private var valueRows: [ModelStatus] {
-        service.models.filter { $0.valueText != nil }
+        service.models.filter { $0.valueText != nil && $0.resetAt == nil }
+    }
+
+    /// Renewal credits: a `valueText` row that also carries an expiry. Grouped under one heading.
+    private var creditRows: [ModelStatus] {
+        service.models.filter { $0.valueText != nil && $0.resetAt != nil }
     }
 
     /// Antigravity grouped by family, preserving first-seen order, each family carrying
@@ -464,6 +501,25 @@ struct ServiceCard: View {
 
     private var hasServiceQuotas: Bool {
         service.name == "Claude" || service.name == "Codex"
+    }
+
+    /// ChatGPT's blocks are labelled by the window they describe — "5h session", "7d session", or
+    /// "30d session" on a ChatGPT Go account — because that account has no per-model rows to name
+    /// instead. Claude keeps "Current session" / "All models": there the model names carry the meaning.
+    private var labelsByWindow: Bool { service.name == "Codex" }
+
+    /// "5h session". The session window is whatever the provider reports, but it's only ever
+    /// classified as one at 6h or below (see `codexWindowIsSession`), so 5 is the honest label.
+    private var sessionWindowLabel: String {
+        String(format: String(localized: "%@ session"), "5\(TimeFormatter.hourUnit)")
+    }
+
+    /// "7d session" / "30d session", from the window's REAL length. nil when the provider didn't
+    /// report one — then the caller keeps its generic label rather than printing a guess.
+    private var longWindowLabel: String? {
+        quotaWindowDays(service.weeklyWindowSeconds).map {
+            String(format: String(localized: "%@ session"), "\($0)\(TimeFormatter.dayUnit)")
+        }
     }
 }
 

--- a/Sources/Mimir/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/en.lproj/Localizable.strings
@@ -43,6 +43,8 @@
 /* Notifications */
 "🚀 %@ weekly quota refilled." = "🚀 %@ weekly quota refilled.";
 "Your weekly quota is back to 100%. Pick up where you left off." = "Your weekly quota is back to 100%. Pick up where you left off.";
+"🚀 %@ monthly quota refilled." = "🚀 %@ monthly quota refilled.";
+"Your monthly quota is back to 100%. Pick up where you left off." = "Your monthly quota is back to 100%. Pick up where you left off.";
 "🔋 %@ ready for a new sprint." = "🔋 %@ ready for a new sprint.";
 "Your 5-hour session is back to 100%. Pick up where you left off." = "Your 5-hour session is back to 100%. Pick up where you left off.";
 "🪫 %@ 5-hour quota running out — %d%%" = "🪫 %@ 5-hour quota running out — %d%%";
@@ -51,6 +53,8 @@
 "🚨 %@ weekly quota running out — %d%%" = "🚨 %@ weekly quota running out — %d%%";
 "Renews in ~%@." = "Renews in ~%@.";
 "Your weekly limit is running out." = "Your weekly limit is running out.";
+"🚨 %@ monthly quota running out — %d%%" = "🚨 %@ monthly quota running out — %d%%";
+"Your monthly limit is running out." = "Your monthly limit is running out.";
 
 /* Status notes */
 "out of date" = "out of date";

--- a/Sources/Mimir/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/en.lproj/Localizable.strings
@@ -20,8 +20,6 @@
 "Usage credit" = "Usage credit";
 "Usage limits" = "Usage limits";
 "Credit balance" = "Credit balance";
-"Reset credits" = "Reset credits";
-"first expires in %@" = "first expires in %@";
 "AI credit" = "AI credit";
 "Resets at %@" = "Resets at %@";
 
@@ -94,5 +92,7 @@
 "Enable" = "Enable";
 "~/.claude/settings.json is not valid JSON" = "~/.claude/settings.json is not valid JSON";
 "couldn't write to ~/.claude" = "couldn't write to ~/.claude";
+"%@ session" = "%@ session";
+"Renewal credits" = "Renewal credits";
 "⏳ Reset credit expires in %@" = "⏳ Reset credit expires in %@";
 "You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses." = "You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses.";

--- a/Sources/Mimir/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/tr.lproj/Localizable.strings
@@ -43,6 +43,8 @@
 /* Notifications */
 "🚀 %@ weekly quota refilled." = "🚀 %@ haftalık kota yenilendi.";
 "Your weekly quota is back to 100%. Pick up where you left off." = "Haftalık kotanız %100 oldu. Kaldığınız yerden devam edebilirsiniz.";
+"🚀 %@ monthly quota refilled." = "🚀 %@ aylık kota yenilendi.";
+"Your monthly quota is back to 100%. Pick up where you left off." = "Aylık kotanız %100 oldu. Kaldığınız yerden devam edebilirsiniz.";
 "🔋 %@ ready for a new sprint." = "🔋 %@ yeni sprint için hazır.";
 "Your 5-hour session is back to 100%. Pick up where you left off." = "5 saatlik oturum %100 oldu. Kaldığınız yerden devam edebilirsiniz.";
 "🪫 %@ 5-hour quota running out — %d%%" = "🪫 %@ 5 saatlik kota tükeniyor. — %%%d";
@@ -51,6 +53,8 @@
 "🚨 %@ weekly quota running out — %d%%" = "🚨 %@ haftalık kota tükeniyor. — %%%d";
 "Renews in ~%@." = "~%@ sonra yenilenecek.";
 "Your weekly limit is running out." = "Haftalık limitin tükeniyor.";
+"🚨 %@ monthly quota running out — %d%%" = "🚨 %@ aylık kota tükeniyor. — %%%d";
+"Your monthly limit is running out." = "Aylık limitin tükeniyor.";
 
 /* Status notes */
 "out of date" = "güncel değil";

--- a/Sources/Mimir/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/tr.lproj/Localizable.strings
@@ -20,8 +20,6 @@
 "Usage credit" = "Kullanım kredisi";
 "Usage limits" = "Kullanım limitleri";
 "Credit balance" = "Kredi bakiyesi";
-"Reset credits" = "Sıfırlama hakkı";
-"first expires in %@" = "ilki %@ sonra doluyor";
 "AI credit" = "AI kredisi";
 "Resets at %@" = "%@'da sıfırlanır";
 
@@ -94,5 +92,7 @@
 "Enable" = "Etkinleştir";
 "~/.claude/settings.json is not valid JSON" = "~/.claude/settings.json geçerli bir JSON değil";
 "couldn't write to ~/.claude" = "~/.claude klasörüne yazılamadı";
-"⏳ Reset credit expires in %@" = "⏳ Sıfırlama hakkı %@ sonra doluyor";
+"%@ session" = "%@ oturum";
+"Renewal credits" = "Yenileme hakları";
+"⏳ Reset credit expires in %@" = "⏳ Yenileme hakkı %@ sonra doluyor";
 "You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses." = "Bekleyen %@ hakkın var. Şimdi kullanırsan tükenmiş pencereyi sıfırlar; kullanmazsan yanar.";

--- a/Sources/MimirShared/WidgetTheme.swift
+++ b/Sources/MimirShared/WidgetTheme.swift
@@ -15,12 +15,12 @@ public extension Color {
     }
 }
 
-/// The one status-colour rule from the design spec: green ≥50%, amber 15–50%, red <15% — derived
+/// The one status-colour rule from the design spec: green ≥40%, amber 10–40%, red <10% — derived
 /// from *remaining* percent (low percent = critical = red). Drives the percentage text and bars.
 public func statusColor(_ percent: Int) -> Color {
     switch max(0, min(100, percent)) {
-    case 50...100: return Color(hex: 0x3FB984)
-    case 15..<50:  return Color(hex: 0xE0A93C)
+    case 40...100: return Color(hex: 0x3FB984)
+    case 10..<40:  return Color(hex: 0xE0A93C)
     default:       return Color(hex: 0xE5564E)
     }
 }

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -268,6 +268,60 @@ final class UsageParsingTests: XCTestCase {
         XCTAssertTrue(status.isAvailable)
     }
 
+    /// A window present but WITHOUT `used_percent` reads as unknown, not full. Pinning it to 100 made a
+    /// partial response look like a fresh reset, which fired "quota refilled" mid-month on the 30-day
+    /// (ChatGPT Go) window. The reset time is still kept, so the countdown survives.
+    func testCodexStatusLeavesPercentNilWhenUsedPercentMissing() {
+        let root: [String: Any] = [
+            "rate_limit": [
+                "primary_window": ["limit_window_seconds": 2_592_000, "reset_at": 1_785_822_607.0],
+            ],
+        ]
+        let status = ds.codexStatus(fromUsageRoot: root)
+        XCTAssertNil(status.weeklyRemainingPercent)                        // unknown, not 100
+        XCTAssertEqual(status.weeklyResetAt, Date(timeIntervalSince1970: 1_785_822_607))
+        XCTAssertEqual(status.weeklyWindowSeconds, 2_592_000)
+    }
+
+    /// The refill alert runs off the window's reset clock, not off the percent: fire once the armed
+    /// reset has passed, and never twice for the same one (the stamp survives a relaunch).
+    func testRefillFiresOncePerArmedReset() {
+        let t: Double = 1_785_000_000
+        XCTAssertTrue(refillIsDue(armed: t, announced: 0, now: t))              // reset came round
+        XCTAssertTrue(refillIsDue(armed: t, announced: t - 1, now: t + 60))     // a later reset
+        XCTAssertFalse(refillIsDue(armed: t, announced: 0, now: t - 1))         // not yet
+        XCTAssertFalse(refillIsDue(armed: t, announced: t, now: t + 60))        // already announced
+        XCTAssertFalse(refillIsDue(armed: 0, announced: 0, now: t))             // nothing armed
+    }
+
+    /// Arming takes the next future reset, once, and refuses the one we already announced — otherwise
+    /// the data rolling forward at reset time would clobber a refill still owed.
+    func testNextArmedResetTakesTheNextFutureResetOnly() {
+        let now = Date(timeIntervalSince1970: 1_785_000_000)
+        let next = now.addingTimeInterval(30 * 86_400)
+        XCTAssertEqual(nextArmedReset(armed: 0, announced: 0, resetAt: next, now: now),
+                       next.timeIntervalSince1970)
+        XCTAssertNil(nextArmedReset(armed: 123, announced: 0, resetAt: next, now: now))   // already armed
+        XCTAssertNil(nextArmedReset(armed: 0, announced: 0, resetAt: nil, now: now))      // no reset reported
+        XCTAssertNil(nextArmedReset(armed: 0, announced: 0,
+                                    resetAt: now.addingTimeInterval(-60), now: now))      // already past
+        XCTAssertNil(nextArmedReset(armed: 0, announced: next.timeIntervalSince1970,
+                                    resetAt: next, now: now))                             // already announced
+    }
+
+    /// The low-quota threshold scales with the window: a flat 10% warns on day three of a 30-day
+    /// ChatGPT Go quota. Anything at or under a week keeps the base, and the floor stops the scaling
+    /// from tightening past a usable warning.
+    func testLowQuotaThresholdScalesWithWindowLength() {
+        XCTAssertEqual(lowQuotaThreshold(windowSeconds: nil), 10)             // unknown → base
+        XCTAssertEqual(lowQuotaThreshold(windowSeconds: 7 * 86_400), 10)      // the week itself
+        XCTAssertEqual(lowQuotaThreshold(windowSeconds: 5 * 86_400), 10)      // shorter → still base
+        XCTAssertEqual(lowQuotaThreshold(windowSeconds: 14 * 86_400), 5)      // scaled to the floor
+        XCTAssertEqual(lowQuotaThreshold(windowSeconds: 2_592_000), 5)        // 30d Go window
+        // Without the floor a 30-day window would warn at 2% — too late to spend the remainder.
+        XCTAssertEqual(lowQuotaThreshold(windowSeconds: 2_592_000, floor: 0), 2)
+    }
+
     /// Credit-only account with neither window → "Codex" shows just the credit balance; both window
     /// readings stay nil (no misleading 100%).
     func testCodexStatusCreditOnly() {

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -154,18 +154,23 @@ final class UsageParsingTests: XCTestCase {
         ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: 1_786_000_000 + offset))
     }
 
-    /// Available and unexpired credits are counted, with the nearest expiry in the caption.
-    func testCodexResetCreditsCountsAvailableOnes() {
+    /// One row per available credit, soonest expiry first, each carrying its own expiry so the popover
+    /// can draw a live countdown and the warning can pick the nearest one.
+    func testCodexResetCreditsRowPerCredit() {
         let root = resetCreditsRoot("""
         {"id": "a", "status": "available", "expires_at": "\(iso(6 * 86_400))", "title": "Reset", "description": ""},
         {"id": "b", "status": "available", "expires_at": "\(iso(3 * 86_400))", "title": "Reset", "description": ""}
         """)
-        let row = ds.codexResetCreditRow(fromRoot: root, now: credalNow)
-        XCTAssertEqual(row?.valueText, "2")
-        XCTAssertEqual(row?.caption, String(format: String(localized: "first expires in %@"),
-                                            TimeFormatter.duration(from: 3 * 86_400)))
-        // The expiry warning reads the nearest expiry off `resetAt`, not the formatted caption.
-        XCTAssertEqual(row?.resetAt, credalNow.addingTimeInterval(3 * 86_400))
+        let rows = ds.codexResetCreditRows(fromRoot: root, now: credalNow)
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows.map(\.resetAt), [credalNow.addingTimeInterval(3 * 86_400),
+                                             credalNow.addingTimeInterval(6 * 86_400)])
+        // Each line is labelled by the date it lapses, in the locale's own short format.
+        XCTAssertEqual(rows[0].name, LiveUsageDataSource.creditDateFormatter
+            .string(from: credalNow.addingTimeInterval(3 * 86_400)))
+        XCTAssertEqual(rows[1].name, LiveUsageDataSource.creditDateFormatter
+            .string(from: credalNow.addingTimeInterval(6 * 86_400)))
+        XCTAssertEqual(rows[0].valueText, TimeFormatter.duration(from: 3 * 86_400))
     }
 
     /// A credit that lapsed between polls, and one that was already spent, are both dropped —
@@ -175,13 +180,13 @@ final class UsageParsingTests: XCTestCase {
         {"id": "a", "status": "available", "expires_at": "\(iso(-3_600))", "title": "", "description": ""},
         {"id": "b", "status": "used", "expires_at": "\(iso(30 * 86_400))", "title": "", "description": ""}
         """)
-        XCTAssertNil(ds.codexResetCreditRow(fromRoot: root, now: credalNow))
+        XCTAssertTrue(ds.codexResetCreditRows(fromRoot: root, now: credalNow).isEmpty)
     }
 
-    /// Empty / missing payload → no row at all, so the card simply doesn't draw the section.
+    /// Empty / missing payload → no rows at all, so the card simply doesn't draw the section.
     func testCodexResetCreditsEmptyPayload() {
-        XCTAssertNil(ds.codexResetCreditRow(fromRoot: ["available_count": 0, "credits": []]))
-        XCTAssertNil(ds.codexResetCreditRow(fromRoot: [:]))
+        XCTAssertTrue(ds.codexResetCreditRows(fromRoot: ["available_count": 0, "credits": []]).isEmpty)
+        XCTAssertTrue(ds.codexResetCreditRows(fromRoot: [:]).isEmpty)
     }
 
     /// Both windows present with real durations: the 5-hour one (limit_window_seconds 18000) is the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [2.8] - 2026-08-09
 
 #### Fixed
-- Codex quota windows are now labelled with their real length instead of always "7d". ChatGPT Go moved its Codex allowance to a roughly monthly window while Plus and Pro stayed weekly, so Go users were told their month-long quota resets in a week. The badge now reads "30d" when the window is a month, "7d" when it's a week — and it comes from the window's full length, not the countdown, so it still says "30d" on day 27.
+- Codex quota windows are now labelled with their real length instead of always "7d". Some accounts report a single month-long window where others still get a weekly one, so a month-long quota was being shown as resetting in a week. The badge now reads whatever length the API reports — "30d" for a month, "7d" for a week — taken from the window's full length, not the countdown, so it still says "30d" on day 27.
 
 #### Internal
 - The quota window's reported length is carried through to the popover and the widget, so any future window size labels itself correctly without a code change. When a provider reports no length, the plain weekly label is kept rather than a guessed number.
@@ -468,7 +468,7 @@ sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) k
 ### [2.8] - 2026-08-09
 
 #### Düzeltildi
-- Codex kota pencereleri artık hep "7g" değil, gerçek uzunluğuyla etiketleniyor. ChatGPT Go, Codex hakkını kabaca aylık bir pencereye taşıdı; Plus ve Pro haftalık kaldı. Bu yüzden Go kullanıcılarına aylık kotaları bir hafta içinde sıfırlanacakmış gibi görünüyordu. Rozet artık pencere bir aylıksa "30g", bir haftalıksa "7g" yazıyor — üstelik geri sayımdan değil pencerenin tam uzunluğundan geldiği için 27. günde bile "30g" diyor.
+- Codex kota pencereleri artık hep "7g" değil, gerçek uzunluğuyla etiketleniyor. Bazı hesaplarda tek bir aylık pencere görülüyor, bazılarında haftalık pencere duruyor; aylık kota bir hafta içinde sıfırlanacakmış gibi gösteriliyordu. Rozet artık API hangi uzunluğu bildiriyorsa onu yazıyor — aylıksa "30g", haftalıksa "7g" — üstelik geri sayımdan değil pencerenin tam uzunluğundan geldiği için 27. günde bile "30g" diyor.
 
 #### İçeride
 - Kota penceresinin bildirilen uzunluğu popover'a ve widget'a kadar taşınıyor; böylece ileride çıkacak herhangi bir pencere boyutu kod değişikliği olmadan doğru etiketleniyor. Sağlayıcı uzunluk bildirmiyorsa tahmini bir sayı yerine düz haftalık etiketi korunuyor.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.13] - 2026-09-05
+
+#### Changed
+- ChatGPT's **reset credits** are now listed one per line, under a single "Renewal credits" heading: the date each one lapses, and how long that is from now. The old row showed only a count with "first expires in …" underneath, which hid the fact that every credit has its own date — and read oddly when there was only one.
+- The ChatGPT card labels its blocks by the window they describe — "5h session" above, "7d session" or "30d session" below. That account has no per-model rows to name instead, and the length is whatever the service reports, so an account on a month-long window reads "30d" without any guesswork.
+- New colour bands: green from 40%, amber 10–39%, red below 10%. Red now means the last tenth of a window rather than the last seventh, and every low-quota notification arrives as the reading turns red — the 5-hour warning used to go off in the middle of amber.
+
+#### Fixed
+- The monthly ChatGPT quota announced refills and warnings that had nothing to do with where the month actually was. Three causes: a reading that flickered back to full was taken for a reset, a reply that omitted the percentage was read as 100%, and the "running out" warning fired at a tenth of a month-long quota — three days of budget still in hand. Refills are now announced on the window's own reset time, an unknown percentage stays unknown, and the warning threshold scales with the window's length.
+- A "running out" warning is no longer repeated after every restart. Mimir remembered what it had already announced only while running, so quitting and reopening brought the same notification back.
+
 ### [2.12] - 2026-09-04
 
 #### Added
@@ -422,6 +433,17 @@ Bu projedeki tüm önemli değişiklikler bu dosyada belgelenecektir.
 
 Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
+
+### [2.13] - 2026-09-05
+
+#### Değiştirildi
+- ChatGPT'nin **yenileme hakları** artık tek tek listeleniyor: "Yenileme hakları" başlığı altında her hakkın yandığı tarih ve ne kadar kaldığı. Eski satır yalnızca adet gösterip altına "ilki … sonra doluyor" yazıyordu; bu hem her hakkın kendi tarihi olduğunu gizliyor hem de tek hak varken tuhaf okunuyordu.
+- ChatGPT kartı bloklarını anlattıkları pencereye göre adlandırıyor — üstte "5s oturum", altta "7g oturum" ya da "30g oturum". Bu hesapta ad taşıyacak model satırları yok; uzunluk da servisin bildirdiği değer olduğu için aylık pencereli bir hesap tahmine gerek kalmadan "30g" görüyor.
+- Yeni renk aralıkları: %40'tan itibaren yeşil, %10–39 amber, %10 altı kırmızı. Kırmızı artık pencerenin son yedide biri değil son onda biri anlamına geliyor ve bütün "kota tükeniyor" bildirimleri okuma kırmızıya dönerken geliyor — 5 saatlik uyarı önceden ambere yeni girmişken ötüyordu.
+
+#### Düzeltildi
+- Aylık ChatGPT kotası, ayın gerçekte neresinde olduğuyla ilgisi olmayan yenilenme ve tükenme bildirimleri gönderiyordu. Üç sebep vardı: bir anlığına dolu görünen okuma sıfırlanma sanılıyordu, yüzdeyi bildirmeyen bir cevap %100 sayılıyordu ve "tükeniyor" uyarısı aylık kotanın onda birinde — daha üç günlük hak dururken — ötüyordu. Yenilenme artık pencerenin kendi sıfırlanma saatinden duyuruluyor, bilinmeyen yüzde bilinmiyor olarak kalıyor ve uyarı eşiği pencerenin uzunluğuna göre ölçekleniyor.
+- "Kota tükeniyor" uyarısı artık her açılışta tekrar gelmiyor. Mimir neyi duyurduğunu yalnızca çalışırken hatırlıyordu; uygulamayı kapatıp açmak aynı bildirimi geri getiriyordu.
 
 ### [2.12] - 2026-09-04
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,13 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [2.13] - 2026-09-05
 
 #### Changed
-- ChatGPT's **reset credits** are now listed one per line, under a single "Renewal credits" heading: the date each one lapses, and how long that is from now. The old row showed only a count with "first expires in …" underneath, which hid the fact that every credit has its own date — and read oddly when there was only one.
-- The ChatGPT card labels its blocks by the window they describe — "5h session" above, "7d session" or "30d session" below. That account has no per-model rows to name instead, and the length is whatever the service reports, so an account on a month-long window reads "30d" without any guesswork.
-- New colour bands: green from 40%, amber 10–39%, red below 10%. Red now means the last tenth of a window rather than the last seventh, and every low-quota notification arrives as the reading turns red — the 5-hour warning used to go off in the middle of amber.
+- ChatGPT's **reset credits** are listed one per line under a "Renewal credits" heading — the date each one lapses, and how long that is. The old row showed a count with "first expires in …" underneath.
+- The ChatGPT card names its blocks by window: "5h session" above, "7d session" or "30d session" below, from whatever length the service reports.
+- New colour bands: green from 40%, amber 10–39%, red below 10%. Every low-quota notification now arrives as the reading turns red.
 
 #### Fixed
-- The monthly ChatGPT quota announced refills and warnings that had nothing to do with where the month actually was. Three causes: a reading that flickered back to full was taken for a reset, a reply that omitted the percentage was read as 100%, and the "running out" warning fired at a tenth of a month-long quota — three days of budget still in hand. Refills are now announced on the window's own reset time, an unknown percentage stays unknown, and the warning threshold scales with the window's length.
-- A "running out" warning is no longer repeated after every restart. Mimir remembered what it had already announced only while running, so quitting and reopening brought the same notification back.
+- The monthly ChatGPT quota announced refills and warnings that had nothing to do with where the month was. Refills now follow the window's own reset time, a reply that omits the percentage no longer reads as 100%, and the warning threshold scales with the window's length.
+- A "running out" warning is no longer repeated after every restart.
 
 ### [2.12] - 2026-09-04
 
@@ -437,13 +437,13 @@ sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) k
 ### [2.13] - 2026-09-05
 
 #### Değiştirildi
-- ChatGPT'nin **yenileme hakları** artık tek tek listeleniyor: "Yenileme hakları" başlığı altında her hakkın yandığı tarih ve ne kadar kaldığı. Eski satır yalnızca adet gösterip altına "ilki … sonra doluyor" yazıyordu; bu hem her hakkın kendi tarihi olduğunu gizliyor hem de tek hak varken tuhaf okunuyordu.
-- ChatGPT kartı bloklarını anlattıkları pencereye göre adlandırıyor — üstte "5s oturum", altta "7g oturum" ya da "30g oturum". Bu hesapta ad taşıyacak model satırları yok; uzunluk da servisin bildirdiği değer olduğu için aylık pencereli bir hesap tahmine gerek kalmadan "30g" görüyor.
-- Yeni renk aralıkları: %40'tan itibaren yeşil, %10–39 amber, %10 altı kırmızı. Kırmızı artık pencerenin son yedide biri değil son onda biri anlamına geliyor ve bütün "kota tükeniyor" bildirimleri okuma kırmızıya dönerken geliyor — 5 saatlik uyarı önceden ambere yeni girmişken ötüyordu.
+- ChatGPT'nin **yenileme hakları** "Yenileme hakları" başlığı altında tek tek listeleniyor — her hakkın yandığı tarih ve ne kadar kaldığı. Eski satır adet gösterip altına "ilki … sonra doluyor" yazıyordu.
+- ChatGPT kartı bloklarını penceresine göre adlandırıyor: üstte "5s oturum", altta servisin bildirdiği uzunluğa göre "7g oturum" ya da "30g oturum".
+- Yeni renk aralıkları: %40'tan itibaren yeşil, %10–39 amber, %10 altı kırmızı. Bütün "kota tükeniyor" bildirimleri artık okuma kırmızıya dönerken geliyor.
 
 #### Düzeltildi
-- Aylık ChatGPT kotası, ayın gerçekte neresinde olduğuyla ilgisi olmayan yenilenme ve tükenme bildirimleri gönderiyordu. Üç sebep vardı: bir anlığına dolu görünen okuma sıfırlanma sanılıyordu, yüzdeyi bildirmeyen bir cevap %100 sayılıyordu ve "tükeniyor" uyarısı aylık kotanın onda birinde — daha üç günlük hak dururken — ötüyordu. Yenilenme artık pencerenin kendi sıfırlanma saatinden duyuruluyor, bilinmeyen yüzde bilinmiyor olarak kalıyor ve uyarı eşiği pencerenin uzunluğuna göre ölçekleniyor.
-- "Kota tükeniyor" uyarısı artık her açılışta tekrar gelmiyor. Mimir neyi duyurduğunu yalnızca çalışırken hatırlıyordu; uygulamayı kapatıp açmak aynı bildirimi geri getiriyordu.
+- Aylık ChatGPT kotası, ayın neresinde olduğuyla ilgisi olmayan yenilenme ve tükenme bildirimleri gönderiyordu. Yenilenme artık pencerenin kendi sıfırlanma saatinden duyuruluyor, yüzdeyi bildirmeyen cevap %100 sayılmıyor ve uyarı eşiği pencerenin uzunluğuna göre ölçekleniyor.
+- "Kota tükeniyor" uyarısı her açılışta tekrar gelmiyor.
 
 ### [2.12] - 2026-09-04
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 [![Platform](https://img.shields.io/badge/platform-macOS%2014%2B-blue)](https://developer.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6.0-orange.svg)](https://swift.org)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/erayendes)
-![YERLİ ÜRETİM](https://img.shields.io/badge/%F0%9F%A4%9D-YERL%C4%B0%20%C3%9CRET%C4%B0M-red)
+[![Yerli üretim](https://img.shields.io/badge/YERL%C4%B0%20%C3%9CRET%C4%B0M-red?style=flat&label=%F0%9F%A4%9D&color=red&link=https%3A%2F%2Fmilowda.com)](https://milowda.com)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,9 +93,9 @@ Mimir's entire UI lives in the menu bar: a small **Mimir glyph** and a vertical 
 
 | Color | Remaining | Meaning |
 |:---:|---|---|
-| 🟢 Green | 50–100% | Plenty left |
-| 🟡 Amber | 15–49% | Running low |
-| 🔴 Red | below 15% | Near the limit |
+| 🟢 Green | 40–100% | Plenty left |
+| 🟡 Amber | 10–39% | Running low |
+| 🔴 Red | below 10% | Near the limit |
 
 **The popover** — click the glyph to open it. Each service is a card with its name and brand icon, the session (5-hour) quota shown prominently with percentage and countdown, a weekly summary row, per-model quota or credit rows, an (i) info icon, and a status note (e.g. *"token expired — open Claude Code"*). When a service has no session window, the weekly reading is promoted into that spot instead. Reset times use short units — e.g. `2h 15m`.
 
@@ -342,9 +342,9 @@ Mimir'in tüm arayüzü menü çubuğunda yaşar: küçük bir **Mimir simgesi**
 
 | Renk | Kalan | Anlamı |
 |:---:|---|---|
-| 🟢 Yeşil | %50–100 | Bol hakkınız var |
-| 🟡 Amber | %15–49 | Azalıyor |
-| 🔴 Kırmızı | %15'in altı | Limite yakın |
+| 🟢 Yeşil | %40–100 | Bol hakkınız var |
+| 🟡 Amber | %10–39 | Azalıyor |
+| 🔴 Kırmızı | %10'un altı | Limite yakın |
 
 **Açılır pencere (popover)** — simgeye tıklayınca açılır. Her servis bir karttır: ad ve marka ikonu, belirgin gösterilen seans (5 saatlik) kotası (yüzde + geri sayım), haftalık özet satırı, per-model kota veya kredi satırları, (i) bilgi simgesi ve bir durum notu (örn. *"token süresi doldu — Claude Code'u aç"*). Bir servisin seans penceresi yoksa haftalık okuma o alana terfi eder. Yenilenme süreleri kısa birimlerle: örn. `2s 15d`.
 


### PR DESCRIPTION
Four things, all reachable from the same report: the ChatGPT quota was announcing
refills and running-out warnings that had nothing to do with where the month
actually was.

## The false alerts

- A `wham/usage` window returned without `used_percent` was read as 100% remaining.
  On a live card that looked exactly like a fresh reset. It stays nil now — unknown,
  not full — keeping only the reset time.
- The refill notice was edge-triggered on the percent crossing back to 100. Codex
  flips between the usage API and the local `.codex/sessions` file, and either can
  hand back a full reading that isn't a reset. Refills now fire off the window's own
  reset clock, the way Antigravity's already did: arm the next reset, announce it once
  it passes, remember that we announced it. Antigravity shares that code now instead
  of carrying its own copy.
- Per-window notification state moves from AppDelegate fields to UserDefaults. These
  alerts are once-per-window, not once-per-launch: in memory, every relaunch re-sent
  the same "running out" notice.
- The low threshold was a flat 10% for any window longer than a session, so a
  month-long quota warned with three days of budget still in hand. It scales with the
  window's real length now (10% at a week, floored at 5%), and the alerts say
  "monthly" and report their own telemetry bucket instead of folding into "weekly".

## Colours and labels

Green starts at 40% and amber runs 10–39%, so red means the last tenth of a window.
The 5-hour low alert drops from 20% to 10% to match — every alert now fires as the
reading turns red. The three copies of the band table (widget, popover, menu-bar dots)
and both README tables move together.

The ChatGPT card labels its blocks by the window they describe — "5h session" above,
"7d session" or "30d session" below — because that account has no per-model rows to
name instead. The length comes from what the API reports, so nothing keys off a plan
name. Claude keeps "Current session" / "All models".

## Renewal credits

The reset-credit row said "1" with "first expires in 29d 4h" underneath — "first"
reads wrong when there is only one, and the count hid the fact that each credit lapses
on its own date. Credits are one line each now, grouped under a single "Renewal
credits" heading so neither the icon nor the label repeats: the date on the left, a
live countdown on the right. The expiry warning picks the nearest expiry across all of
them and counts the rest.

## Reviewing it

`MIMIR_DEMO_SHOT=/tmp/shot.png .build/debug/Mimir` renders the popover's cards to a PNG
from fixtures, so a card change can be reviewed without running the menu-bar app.
DEBUG-only.

## A note on the ChatGPT Go claim

The changelog said ChatGPT Go moved its Codex allowance to a monthly window while Plus
and Pro stayed weekly. That was never verified — PR #39 said as much in its own message.
What is documented: OpenAI has been replacing the 5-hour + weekly pair with a single
monthly limit on some accounts across Go, Plus, Pro and Business
(openai/codex#31914, #41968, #32707), and a Go user reported a reset date that keeps
sliding forward. No public payload shows the window's exact length. The changelog entry
is softened to match; the code never keyed off a plan name in the first place.

107 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)