### PR TITLE
feat(popover): let the numbers carry the card, and name every row by what it is

### DIFF
--- a/Sources/Mimir/ClaudeProvider.swift
+++ b/Sources/Mimir/ClaudeProvider.swift
@@ -225,6 +225,21 @@ extension LiveUsageDataSource {
     /// Billing/credits row. Prefers the new `spend` object (richer: cap, balance, auto_reload,
     /// disclaimer) and falls back to the legacy `extra_usage` shape for accounts the API hasn't
     /// migrated yet — both are read defensively since neither's rollout is guaranteed complete.
+
+    /// Money as the symbol plus the amount ("$18.40"), which reads shorter than "18.40 USD" in a row
+    /// that has to fit a used/limit pair. A currency with no known symbol keeps its code ("TRY 18.40"),
+    /// so an unfamiliar one is still unambiguous. Whole amounts drop the ".00".
+    func formattedMoney(_ value: Double, currency: String) -> String {
+        let whole = value.truncatingRemainder(dividingBy: 1) == 0
+        guard !currency.isEmpty else { return whole ? String(Int(value)) : String(format: "%.2f", value) }
+        let f = NumberFormatter()
+        f.numberStyle = .currency
+        f.currencyCode = currency
+        f.locale = Locale(identifier: "en_US")
+        f.maximumFractionDigits = whole ? 0 : 2
+        return f.string(from: NSNumber(value: value)) ?? "\(value) \(currency)"
+    }
+
     private func claudeBillingRow(_ root: [String: Any]) -> ModelStatus? {
         if let spend = root["spend"] as? [String: Any], spend["enabled"] as? Bool == true {
             return claudeSpendBillingRow(spend)
@@ -239,16 +254,13 @@ extension LiveUsageDataSource {
         let used = (doubleValue(usedObj["amount_minor"]) ?? 0) / scale
         let cur = (usedObj["currency"] as? String)?.uppercased() ?? ""
         let limit = (spend["limit"] as? [String: Any]).flatMap { doubleValue($0["amount_minor"]) }.map { $0 / scale }
-        func money(_ v: Double) -> String {
-            let n = v.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(v)) : String(format: "%.2f", v)
-            return cur.isEmpty ? n : "\(n) \(cur)"
-        }
+        func money(_ v: Double) -> String { formattedMoney(v, currency: cur) }
         let text = limit.map { "\(money(used)) / \(money($0))" } ?? money(used)
         let util = doubleValue(spend["percent"]) ?? (limit.map { $0 > 0 ? used / $0 * 100 : 0 } ?? 0)
         // Prefer the API's own judgement when it ships one; otherwise the 80%-of-cap heuristic.
         let low = (spend["severity"] as? String)
             .map { !["none", "normal", "ok"].contains($0.lowercased()) } ?? (util >= 80)
-        return ModelStatus(name: String(localized: "Usage credit"), remainingPercent: 0, resetAt: nil,
+        return ModelStatus(name: String(localized: "Spending"), remainingPercent: 0, resetAt: nil,
                            valueText: text, isLow: low, symbol: "dollarsign.circle")
     }
 
@@ -257,13 +269,10 @@ extension LiveUsageDataSource {
         let used = doubleValue(e["used_credits"]) ?? 0
         let limit = doubleValue(e["monthly_limit"])
         let cur = (e["currency"] as? String).map { $0.uppercased() } ?? ""
-        func money(_ v: Double) -> String {
-            let n = v.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(v)) : String(format: "%.2f", v)
-            return cur.isEmpty ? n : "\(n) \(cur)"
-        }
+        func money(_ v: Double) -> String { formattedMoney(v, currency: cur) }
         let text = limit.map { "\(money(used)) / \(money($0))" } ?? money(used)
         let util = doubleValue(e["utilization"]) ?? (limit.map { $0 > 0 ? used / $0 * 100 : 0 } ?? 0)
-        return ModelStatus(name: String(localized: "Usage credit"), remainingPercent: 0, resetAt: nil,
+        return ModelStatus(name: String(localized: "Spending"), remainingPercent: 0, resetAt: nil,
                            valueText: text, isLow: util >= 80, symbol: "dollarsign.circle")
     }
     private func mergeClaudeWindows(root: [String: Any], baseKey: String) -> (utilization: Double, resetAt: Date?) {

--- a/Sources/Mimir/CodexProvider.swift
+++ b/Sources/Mimir/CodexProvider.swift
@@ -218,12 +218,15 @@ extension LiveUsageDataSource {
         }
     }
 
-    /// Locale's own short date ("19.10.2026" in tr, "10/19/2026" in en) — a credit's expiry is a
-    /// calendar date, not a countdown, so it reads as one.
+    /// Fixed dd.MM.yyyy — a credit's expiry is a calendar date, not a countdown, so it reads as one.
+    /// Not the locale's short style: that dropped the leading zero ("8.09.2026"), so a column of dates
+    /// didn't line up. `yyyy` (calendar year), never `YYYY` (week-year, which is off by one in late
+    /// December). POSIX locale so a non-Gregorian regional calendar can't reformat it.
     static let creditDateFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.dateStyle = .short
-        f.timeStyle = .none
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.calendar = Calendar(identifier: .gregorian)
+        f.dateFormat = "dd.MM.yyyy"
         return f
     }()
 

--- a/Sources/Mimir/DemoShot.swift
+++ b/Sources/Mimir/DemoShot.swift
@@ -16,6 +16,8 @@ enum DemoShot {
             models: [
                 ModelStatus(name: "Fable", remainingPercent: 100,
                             resetAt: now.addingTimeInterval(3 * 86_400 + 19 * 3600), window: .weekly),
+                ModelStatus(name: String(localized: "Spending"), remainingPercent: 0, resetAt: nil,
+                            valueText: "$18.40 / $40", symbol: "dollarsign.circle"),
             ],
             isAvailable: true, statusNote: "demo")
 
@@ -32,12 +34,33 @@ enum DemoShot {
             weeklyResetAt: now.addingTimeInterval(6 * 86_400 + 13 * 3600),
             sessionRemainingPercent: 91, weeklyRemainingPercent: 91,
             weeklyWindowSeconds: 2_592_000,
-            models: credits,
+            models: [ModelStatus(name: String(localized: "Credit balance"), remainingPercent: 0,
+                                 resetAt: nil, valueText: "42 kredi", symbol: "dollarsign.circle")] + credits,
+            isAvailable: true, statusNote: "demo")
+
+        // Antigravity carries per-family rows instead of account windows — and it's where the amber
+        // and red bands show up in this render.
+        let antigravity = ServiceStatus(
+            name: "Antigravity", iconName: "antigravity",
+            sessionResetAt: nil, weeklyResetAt: nil,
+            models: [
+                ModelStatus(name: "Gemini", remainingPercent: 28,
+                            resetAt: now.addingTimeInterval(2 * 3600 + 40 * 60), window: .session),
+                ModelStatus(name: "Gemini", remainingPercent: 44,
+                            resetAt: now.addingTimeInterval(4 * 86_400), window: .weekly),
+                ModelStatus(name: "Claude/GPT", remainingPercent: 6,
+                            resetAt: now.addingTimeInterval(51 * 60), window: .session),
+                ModelStatus(name: "Claude/GPT", remainingPercent: 9,
+                            resetAt: now.addingTimeInterval(4 * 86_400), window: .weekly),
+                ModelStatus(name: String(localized: "AI credit"), remainingPercent: 0, resetAt: nil,
+                            valueText: "1250", symbol: "sparkles"),
+            ],
             isAvailable: true, statusNote: "demo")
 
         let view = VStack(spacing: 11) {
             ServiceCard(service: claude, now: now)
             ServiceCard(service: codex, now: now)
+            ServiceCard(service: antigravity, now: now)
         }
         .padding(11)
         .frame(width: PopoverMetrics.width)

--- a/Sources/Mimir/PopoverViews.swift
+++ b/Sources/Mimir/PopoverViews.swift
@@ -271,7 +271,7 @@ struct ServiceCard: View {
             // so the header stays quiet and the quota block is the loudest thing on the card.
             HStack(spacing: 6) {
                 BrandIconView(iconName: service.iconName, size: 11)
-                    .foregroundStyle(Color.primary.opacity(0.45))
+                    .foregroundStyle(Color.primary.opacity(0.5))
                     .frame(width: 11, height: 11)
                 Text(cardTitle.uppercased())
                     .font(.system(size: 10, weight: .medium))
@@ -324,11 +324,15 @@ struct ServiceCard: View {
                             cardDivider.padding(.top, 13).padding(.bottom, 13)
                         }
                         if let session = family.session {
-                            QuotaBlock(label: family.name, percent: session.percent, resetAt: session.resetAt,
+                            QuotaBlock(label: "\(family.name) 5\(TimeFormatter.hourUnit)",
+                                       percent: session.percent, resetAt: session.resetAt,
                                        now: now, gated: family.weekly?.percent == 0)
                         }
                         if let weekly = family.weekly {
-                            modelRow((label: family.name, percent: weekly.percent, resetAt: weekly.resetAt))
+                            // Antigravity's two rows per family are the same name twice; the window is
+                            // what tells them apart, so each carries it. Its long window is always 7 days.
+                            modelRow((label: "\(family.name) 7\(TimeFormatter.dayUnit)",
+                                      percent: weekly.percent, resetAt: weekly.resetAt))
                                 .padding(.top, family.session != nil ? 9 : 0)
                         }
                     }
@@ -344,9 +348,10 @@ struct ServiceCard: View {
                     if !creditRows.isEmpty {
                         // One heading for the whole group, then a line per credit — repeating the icon
                         // and the label on every line read as noise.
-                        HStack(spacing: 5) {
-                            Image(systemName: "arrow.clockwise").font(.system(size: 11, weight: .regular))
-                            Text(String(localized: "Renewal credits"))
+                        HStack(spacing: 8) {
+                            Image(systemName: "plus.circle").font(.system(size: 11, weight: .regular))
+                                .frame(width: Self.iconColumn)
+                            Text(String(localized: "Renewal credit"))
                         }
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(Color.primary.opacity(0.58))
@@ -367,16 +372,21 @@ struct ServiceCard: View {
             .frame(height: 1)
     }
 
+    /// Width of the leading icon column. Symbols and status dots are different sizes, so both are
+    /// centred in a column of this width — otherwise a 7pt dot sits left of the symbol above it.
+    static let iconColumn: CGFloat = 12
+
     /// A secondary quota row: status dot + "Name: %X" + its remaining time on the right.
     private func modelRow(_ entry: (label: String, percent: Int, resetAt: Date?)) -> some View {
         HStack(spacing: 8) {
             Circle()
                 .fill(quotaStatusColor(entry.percent))
                 .frame(width: 7, height: 7)
+                .frame(width: Self.iconColumn)
             Text("\(entry.label): ").font(.system(size: 11, weight: .medium))
-                .foregroundStyle(Color.primary.opacity(0.72))
+                .foregroundStyle(Color.primary.opacity(0.58))
                 + Text("%\(clampPct(entry.percent))").font(.system(size: 11, weight: .medium).monospacedDigit())
-                .foregroundStyle(Color.primary.opacity(0.9))
+                .foregroundStyle(Color.primary.opacity(0.95))
             Spacer(minLength: 6)
             Text(relDuration(entry.resetAt, now) ?? "—")
                 .font(.system(size: 11, weight: .medium).monospacedDigit())
@@ -401,7 +411,7 @@ struct ServiceCard: View {
                 Spacer(minLength: 6)
                 Text(row.valueText ?? "")
                     .font(.system(size: 11, weight: .medium).monospacedDigit())
-                    .foregroundStyle(Color.primary.opacity(0.9))
+                    .foregroundStyle(Color.primary.opacity(0.95))
             }
             if let caption = row.caption {
                 Text(caption)
@@ -412,9 +422,15 @@ struct ServiceCard: View {
         .lineLimit(1)
     }
 
-    /// One renewal credit: the date it lapses, and how long that is from now.
+    /// One renewal credit: the date it lapses, and how long that is from now. The dot matches the
+    /// model rows' size but never changes colour — a credit is either there or it isn't, so there's
+    /// no level for a status colour to describe.
     private func creditRow(_ row: ModelStatus) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Circle()
+                .fill(quotaStatusColor(100))
+                .frame(width: 7, height: 7)
+                .frame(width: Self.iconColumn)
             Text(row.name)
                 .font(.system(size: 11, weight: .medium).monospacedDigit())
                 .foregroundStyle(Color.primary.opacity(0.58))
@@ -576,7 +592,7 @@ struct QuotaBlock: View {
                     // full window length rather than a bare dash.
                     Text(relDuration(resetAt, now) ?? TimeFormatter.duration(from: windowFallback))
                 } icon: {
-                    Image(systemName: "hourglass")
+                    Image(systemName: "timer").frame(width: ServiceCard.iconColumn)
                 }
                 Spacer(minLength: 4)
                 if let resetClock {
@@ -588,7 +604,7 @@ struct QuotaBlock: View {
                 }
             }
             .font(.system(size: 11, weight: .medium).monospacedDigit())
-            .foregroundStyle(Color.primary.opacity(0.5))
+            .foregroundStyle(Color.primary.opacity(0.9))
             .labelStyle(.titleAndIcon)
             .padding(.top, 7)
         }

--- a/Sources/Mimir/PopoverViews.swift
+++ b/Sources/Mimir/PopoverViews.swift
@@ -471,8 +471,9 @@ struct ServiceCard: View {
     /// a label that says so, rather than leaving the card without a headline number.
     private var sessionHero: (label: String, percent: Int, resetAt: Date?, fallback: TimeInterval, gated: Bool)? {
         if let session = service.sessionRemainingPercent {
-            let label = labelsByWindow ? sessionWindowLabel : String(localized: "Current session")
-            return (label, session, service.sessionResetAt,
+            // Every 5-hour block says so, Claude included: "Current session" named the block without
+            // saying which window it was, next to rows that name theirs.
+            return (sessionWindowLabel, session, service.sessionResetAt,
                     5 * 3600, service.weeklyRemainingPercent == 0)
         }
         if let weekly = service.weeklyRemainingPercent {
@@ -519,23 +520,27 @@ struct ServiceCard: View {
         service.name == "Claude" || service.name == "Codex"
     }
 
-    /// ChatGPT's blocks are labelled by the window they describe — "5h session", "7d session", or
-    /// "30d session" on a ChatGPT Go account — because that account has no per-model rows to name
-    /// instead. Claude keeps "Current session" / "All models": there the model names carry the meaning.
+    /// Should the LONG window be labelled by its length ("7d session", "30d session") rather than
+    /// "All models"? Only for ChatGPT, which has no per-model rows to name instead; on Claude those
+    /// rows carry the meaning, so its account row stays "All models". The 5-hour block names its
+    /// window on every provider.
     private var labelsByWindow: Bool { service.name == "Codex" }
 
     /// "5h session". The session window is whatever the provider reports, but it's only ever
     /// classified as one at 6h or below (see `codexWindowIsSession`), so 5 is the honest label.
     private var sessionWindowLabel: String {
-        String(format: String(localized: "%@ session"), "5\(TimeFormatter.hourUnit)")
+        Self.windowLabel("5\(TimeFormatter.hourUnit)")
+    }
+
+    /// "<window> session", the one phrasing every card uses for a quota window.
+    static func windowLabel(_ window: String) -> String {
+        String(format: String(localized: "%@ session"), window)
     }
 
     /// "7d session" / "30d session", from the window's REAL length. nil when the provider didn't
     /// report one — then the caller keeps its generic label rather than printing a guess.
     private var longWindowLabel: String? {
-        quotaWindowDays(service.weeklyWindowSeconds).map {
-            String(format: String(localized: "%@ session"), "\($0)\(TimeFormatter.dayUnit)")
-        }
+        quotaWindowDays(service.weeklyWindowSeconds).map { Self.windowLabel("\($0)\(TimeFormatter.dayUnit)") }
     }
 }
 

--- a/Sources/Mimir/Resources/en.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/en.lproj/Localizable.strings
@@ -17,8 +17,8 @@
 "5h session" = "5h session";
 "5h session · %@" = "5h session · %@";
 "All models" = "All models";
-"Usage credit" = "Usage credit";
 "Usage limits" = "Usage limits";
+"Spending" = "Spending";
 "Credit balance" = "Credit balance";
 "AI credit" = "AI credit";
 "Resets at %@" = "Resets at %@";
@@ -93,6 +93,6 @@
 "~/.claude/settings.json is not valid JSON" = "~/.claude/settings.json is not valid JSON";
 "couldn't write to ~/.claude" = "couldn't write to ~/.claude";
 "%@ session" = "%@ session";
-"Renewal credits" = "Renewal credits";
+"Renewal credit" = "Renewal credit";
 "⏳ Reset credit expires in %@" = "⏳ Reset credit expires in %@";
 "You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses." = "You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses.";

--- a/Sources/Mimir/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Mimir/Resources/tr.lproj/Localizable.strings
@@ -17,8 +17,8 @@
 "5h session" = "5 saatlik oturum";
 "5h session · %@" = "5 saatlik oturum · %@";
 "All models" = "Tüm modeller";
-"Usage credit" = "Kullanım kredisi";
 "Usage limits" = "Kullanım limitleri";
+"Spending" = "Harcama";
 "Credit balance" = "Kredi bakiyesi";
 "AI credit" = "AI kredisi";
 "Resets at %@" = "%@'da sıfırlanır";
@@ -93,6 +93,6 @@
 "~/.claude/settings.json is not valid JSON" = "~/.claude/settings.json geçerli bir JSON değil";
 "couldn't write to ~/.claude" = "~/.claude klasörüne yazılamadı";
 "%@ session" = "%@ oturum";
-"Renewal credits" = "Yenileme hakları";
+"Renewal credit" = "Yenileme hakkı";
 "⏳ Reset credit expires in %@" = "⏳ Yenileme hakkı %@ sonra doluyor";
 "You have %@ waiting. Spend one now and it clears a used-up window — unused, it just lapses." = "Bekleyen %@ hakkın var. Şimdi kullanırsan tükenmiş pencereyi sıfırlar; kullanmazsan yanar.";

--- a/Tests/MimirTests/UsageParsingTests.swift
+++ b/Tests/MimirTests/UsageParsingTests.swift
@@ -592,7 +592,7 @@ final class UsageParsingTests: XCTestCase {
         ]
         let status = ds.buildClaudeStatus(from: root, note: "oauth usage api")
         let billing = status.models.first { $0.valueText != nil }
-        XCTAssertEqual(billing?.valueText, "5 USD / 10 USD")
+        XCTAssertEqual(billing?.valueText, "$5 / $10")
     }
 
     /// Claude Code now writes per-config keychain items ("Claude Code-credentials-<hash>") and can

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.14] - 2026-09-05
+
+#### Changed
+- The card now reads by its numbers: countdowns, reset clocks, percentages and amounts are bright, while the words naming them step back. Same size and weight — only the tone separates a label from its number.
+- Every quota block says which window it is — "5h session" above, "7d session" or "30d session" below. Antigravity puts its family first ("Gemini 5h"), since one card there holds more than one.
+- Rows are named for what they hold. Claude's billing row is **Spending**: it shows money spent against your cap, which climbs, where a "credit" reads as something that counts down. Amounts use the currency symbol — `$18.40 / $40`.
+- ChatGPT's **renewal credits** are listed one per line under a single heading, each with the date it lapses and how long that is.
+- Fresh icons: a timer for the countdown, a plus for the renewal group, and a shared column so every icon and status dot lines up.
+
 ### [2.13] - 2026-09-05
 
 #### Changed
@@ -433,6 +442,15 @@ Bu projedeki tüm önemli değişiklikler bu dosyada belgelenecektir.
 
 Format [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standardına,
 sürümlendirme ise [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kurallarına uygundur.
+
+### [2.14] - 2026-09-05
+
+#### Değiştirildi
+- Kart artık sayılarıyla okunuyor: geri sayımlar, sıfırlanma saatleri, yüzdeler ve tutarlar parlak; onları adlandıran kelimeler geri çekildi. Boyut ve ağırlık aynı — etiketi sayısından yalnızca ton ayırıyor.
+- Her kota bloğu hangi pencere olduğunu söylüyor: üstte "5s oturum", altta "7g oturum" ya da "30g oturum". Antigravity'de aile adı önde ("Gemini 5s"), çünkü orada tek kartta birden fazla aile var.
+- Satırlar taşıdıkları şeyin adını aldı. Claude'un fatura satırı artık **Harcama**: tavanına doğru artan bir tutarı gösteriyor, oysa "kredi" azalan bir şey gibi okunuyordu. Tutarlar para birimi simgesiyle — `$18.40 / $40`.
+- ChatGPT'nin **yenileme hakları** tek başlık altında tek tek listeleniyor; her satırda yandığı tarih ve ne kadar kaldığı yazıyor.
+- Yeni ikonlar: geri sayım için timer, yenileme grubu için artı; ayrıca ortak bir sütun sayesinde bütün ikonlar ve durum noktaları hizalı.
 
 ### [2.13] - 2026-09-05
 


### PR DESCRIPTION
## Contrast

The card's quiet parts were the ones people actually read. The countdown and reset
clock go from 50% to 90% opacity; a model row's percentage and a value row's amount
go to 95%, while the words naming them drop to 58%. Same size and weight throughout —
only the tone separates a label from its number. The secondary countdowns on the right
stay at 42% on purpose: brightening those made them compete with the percentages.

## Names

Rows now say what they hold rather than what they were once called.

- **Claude's billing row is "Spending"**, not "Usage credit". It shows money spent
  against the cap you set, so it climbs while the other two count down — calling it a
  credit read as a balance that grows as you spend. Amounts carry their currency symbol
  (`$18.40 / $40`) instead of a trailing code, which also stops the pair from being
  truncated in a 288pt card. A currency with no known symbol keeps its code
  (`TRY 18.40`), so it is never ambiguous.
- **ChatGPT's renewal credits** are one line each under a single heading, dated
  `dd.MM.yyyy` with a leading zero so a column of them lines up (the locale's short
  style dropped it). Each takes the same green dot as a model row: a credit is either
  there or it isn't, so there's no level for a status colour to describe.
- **Antigravity's two rows per family** were the same name twice — the window is what
  tells them apart, so each carries it: "Gemini 5h" and "Gemini 7d".

## Icons

The hourglass becomes a timer, the renewal group takes `plus.circle`, and a brand mark
now matches the tone of the title beside it. Symbols and status dots are different
sizes, so both are centred in a shared 12pt column — a 7pt dot used to sit left of the
symbol above it.

## Reviewing it

`MIMIR_DEMO_SHOT=/tmp/shot.png .build/debug/Mimir` renders the cards from fixtures,
which now cover all three providers and all three colour bands.

107 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)